### PR TITLE
Implement ADR-0010 group scope, commands, and geometry handling

### DIFF
--- a/e2e/tests/floating-toolbar.spec.ts
+++ b/e2e/tests/floating-toolbar.spec.ts
@@ -134,8 +134,8 @@ test("floating toolbar shows layout commands and omits duplicate/delete", async 
   await editableHeading.click();
   await clickFloatingToolbarButton(page, "Group");
   const groupMenu = toolbar.getByRole("menu");
-  await expect(groupMenu.getByRole("button", { name: "Group", exact: true })).toBeVisible();
-  await expect(groupMenu.getByRole("button", { name: "Ungroup", exact: true })).toBeVisible();
+  await expect(groupMenu.getByRole("button", { name: "Group", exact: true })).toBeDisabled();
+  await expect(groupMenu.getByRole("button", { name: "Ungroup", exact: true })).toBeDisabled();
   await expect(groupMenu.getByRole("button", { name: "Duplicate", exact: true })).toBeHidden();
   await expect(groupMenu.getByRole("button", { name: "Delete", exact: true })).toBeHidden();
 
@@ -158,6 +158,10 @@ test("selected group toolbar only exposes layout and organization controls", asy
     toolbar.getByRole("button", { name: "Layer, Align, Distribute", exact: true })
   ).toBeVisible();
   await expect(toolbar.getByRole("button", { name: "Group", exact: true })).toBeVisible();
+  await clickFloatingToolbarButton(page, "Group");
+  await expect(
+    toolbar.getByRole("menu").getByRole("button", { name: "Ungroup", exact: true })
+  ).toBeEnabled();
 
   await expect(toolbar.getByRole("button", { name: "Font", exact: true })).toBeHidden();
   await expect(toolbar.getByRole("button", { name: "Paragraph", exact: true })).toBeHidden();

--- a/sample-slides/12-snap-siblings.html
+++ b/sample-slides/12-snap-siblings.html
@@ -125,21 +125,25 @@
         <h1 data-editable="text" data-editor-id="text-2">Three isolated cards for sibling edge and equal spacing snaps</h1>
         <p data-editable="text" data-editor-id="text-3">The cards are intentionally identical. Drag Card C to the sibling edge or empty equal-spacing slot after Card B.</p>
       </section>
-      <article class="snap-card snap-a" data-editable="block" data-editor-id="snap-card-a">
-        <strong data-editable="text" data-editor-id="text-5">Card A</strong>
-        <span data-editable="text" data-editor-id="text-6">Fixed spacing source</span>
+      <div data-editable="block" data-group="true" data-editor-id="group-3" style="position: absolute; left: 232.77px; top: 181.63px; width: 1266.53px; height: 778.41px;"><article class="snap-card snap-a" data-editable="block" data-editor-id="snap-card-a" style="position: absolute; left: 0px; top: 331.77px; width: 727.23px; height: 195.68px; transform-origin: center center;">
+        <strong data-editable="text" data-editor-id="text-5" style="position: absolute; left: 31.35px; top: 28.18px; width: 254.53px; height: 41.3px; transform-origin: center center;">Card A</strong>
+        <span data-editable="text" data-editor-id="text-6" style="position: absolute; left: 31.35px; top: 82.52px; width: 254.53px; height: 29.34px; transform-origin: center center;">Fixed spacing source</span>
         <div class="snap-drag-surface"></div>
-      </article>
-      <article class="snap-card snap-b" data-editable="block" data-editor-id="snap-card-b">
-        <strong data-editable="text" data-editor-id="text-8">Card B</strong>
-        <span data-editable="text" data-editor-id="text-9">Fixed spacing source</span>
+      </article><article class="snap-card snap-b" data-editable="block" data-editor-id="snap-card-b" style="position: absolute; left: 412.09px; top: 331.77px; width: 727.23px; height: 195.68px; transform-origin: center center;">
+        <strong data-editable="text" data-editor-id="text-8" style="position: absolute; left: 31.35px; top: 28.18px; width: 254.53px; height: 41.3px; transform-origin: center center;">Card B</strong>
+        <span data-editable="text" data-editor-id="text-9" style="position: absolute; left: 31.35px; top: 82.52px; width: 254.53px; height: 29.34px; transform-origin: center center;">Fixed spacing source</span>
         <div class="snap-drag-surface"></div>
-      </article>
-      <article class="snap-card snap-c" data-editable="block" data-editor-id="snap-card-c">
+      </article><article class="snap-card snap-c" data-editable="block" data-editor-id="snap-card-c" style="position: absolute; left: 987.23px; top: 288.36px; width: 279.3px; height: 490.05px; transform-origin: center center;">
         <strong data-editable="text" data-editor-id="text-11">Card C</strong>
         <span data-editable="text" data-editor-id="text-12">Drag this card</span>
         <div class="snap-drag-surface"></div>
-      </article>
+      </article><article class="snap-card snap-c" data-editable="block" data-editor-id="snap-card-c-copy" style="position: absolute; left: 987.23px; top: 0px; width: 279.3px; height: 490.05px; transform-origin: center center; margin: 0px; box-sizing: border-box;">
+        <strong data-editable="text" data-editor-id="snap-card-c-copy-text-11">Card C</strong>
+        <span data-editable="text" data-editor-id="snap-card-c-copy-text-12">Drag this card</span>
+        <div class="snap-drag-surface"></div>
+      </article></div>
+      
+      
     
     </div>
   

--- a/src/core/generated-deck.test.ts
+++ b/src/core/generated-deck.test.ts
@@ -165,7 +165,7 @@ describe("generated deck import", () => {
     const secondSlide = parseSlide(secondSlideHtml, "generated-slide-2");
 
     expect(manifest.topic).toBe(regressionDeckConfig.topic);
-    expect(manifest.slides).toHaveLength(13);
+    expect(manifest.slides).toHaveLength(14);
     expect(firstSlide.id).toBe("generated-slide-1");
     expect(firstSlide.width).toBe(DEFAULT_SLIDE_WIDTH);
     expect(firstSlide.height).toBe(DEFAULT_SLIDE_HEIGHT);

--- a/src/core/slide-operations.test.ts
+++ b/src/core/slide-operations.test.ts
@@ -246,6 +246,88 @@ describe("HTML write-back", () => {
     expect(operation?.nextHtmlSource).toContain('data-group="true"');
   });
 
+  test("group create converts children to group-relative coordinates", () => {
+    const html = ensureEditableSelectors(`<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <div class="slide-container" data-slide-root="true">
+      <p data-editable="text" data-editor-id="text-1" style="left: 100px; top: 80px; width: 120px; height: 40px;">Alpha</p>
+      <div data-editable="block" data-editor-id="block-2" style="left: 260px; top: 140px; width: 160px; height: 90px;">Beta</div>
+    </div>
+  </body>
+</html>`);
+
+    const operation = createGroupCreateOperation({
+      html,
+      slideId: "slide-1",
+      groupElementId: "group-new",
+      elementIds: ["text-1", "block-2"],
+      timestamp: 3,
+    });
+    const doc = new DOMParser().parseFromString(operation?.nextHtmlSource ?? "", "text/html");
+    const group = doc.querySelector<HTMLElement>('[data-editor-id="group-new"]');
+    const firstChild = doc.querySelector<HTMLElement>('[data-editor-id="text-1"]');
+    const secondChild = doc.querySelector<HTMLElement>('[data-editor-id="block-2"]');
+
+    expect(operation?.type).toBe("group.create");
+    expect(group?.style.left).toBe("100px");
+    expect(group?.style.top).toBe("80px");
+    expect(group?.style.width).toBe("320px");
+    expect(group?.style.height).toBe("150px");
+    expect(firstChild?.parentElement).toBe(group);
+    expect(firstChild?.style.left).toBe("0px");
+    expect(firstChild?.style.top).toBe("0px");
+    expect(secondChild?.parentElement).toBe(group);
+    expect(secondChild?.style.left).toBe("160px");
+    expect(secondChild?.style.top).toBe("60px");
+  });
+
+  test("group create rejects cross-parent selections", () => {
+    const html = ensureEditableSelectors(`<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <div class="slide-container" data-slide-root="true">
+      <div data-editable="block" data-editor-id="block-1" style="left: 40px; top: 40px; width: 300px; height: 200px;">
+        <p data-editable="text" data-editor-id="text-2" style="left: 10px; top: 10px; width: 100px; height: 40px;">Nested</p>
+      </div>
+      <p data-editable="text" data-editor-id="text-3" style="left: 420px; top: 80px; width: 100px; height: 40px;">Peer</p>
+    </div>
+  </body>
+</html>`);
+
+    const operation = createGroupCreateOperation({
+      html,
+      slideId: "slide-1",
+      groupElementId: "group-new",
+      elementIds: ["text-2", "text-3"],
+      timestamp: 4,
+    });
+
+    expect(operation).toBeNull();
+  });
+
+  test("group ungroup ignores ordinary blocks with nested editables", () => {
+    const html = ensureEditableSelectors(`<!DOCTYPE html>
+<html lang="en">
+  <body>
+    <div class="slide-container" data-slide-root="true">
+      <div data-editable="block" data-editor-id="block-1" style="left: 100px; top: 80px; width: 300px; height: 200px;">
+        <p data-editable="text" data-editor-id="text-2" style="left: 10px; top: 12px; width: 120px; height: 40px;">Alpha</p>
+      </div>
+    </div>
+  </body>
+</html>`);
+
+    const operation = createGroupUngroupOperation({
+      html,
+      slideId: "slide-1",
+      groupElementId: "block-1",
+      timestamp: 5,
+    });
+
+    expect(operation).toBeNull();
+  });
+
   test("group ungroup restores children to parent order and coordinate space", () => {
     const html = ensureEditableSelectors(`<!DOCTYPE html>
 <html lang="en">

--- a/src/core/slide-operations.ts
+++ b/src/core/slide-operations.ts
@@ -33,6 +33,11 @@ import type {
   SlideOperation,
 } from "./slide-operation-types";
 
+export type GroupElementRectMap = Record<
+  string,
+  { x: number; y: number; width: number; height: number }
+>;
+
 function numericStyleValue(value: string | null | undefined): number {
   const parsed = Number.parseFloat(value || "");
   return Number.isFinite(parsed) ? parsed : 0;
@@ -48,7 +53,10 @@ function getNodeRect(node: HTMLElement): { x: number; y: number; width: number; 
   };
 }
 
-function getAbsoluteNodeRect(node: HTMLElement): {
+function getAbsoluteNodeRect(
+  node: HTMLElement,
+  elementRects: GroupElementRectMap = {}
+): {
   x: number;
   y: number;
   width: number;
@@ -61,7 +69,8 @@ function getAbsoluteNodeRect(node: HTMLElement): {
   let height = 0;
 
   while (current) {
-    const rect = getNodeRect(current);
+    const elementId = current.getAttribute(SELECTOR_ATTR) ?? "";
+    const rect = elementRects[elementId] ?? getNodeRect(current);
     x += rect.x;
     y += rect.y;
     width = rect.width;
@@ -78,13 +87,16 @@ function getAbsoluteNodeRect(node: HTMLElement): {
   return { x, y, width, height };
 }
 
-function getEditableAncestorRect(node: HTMLElement): { x: number; y: number } {
+function getEditableAncestorRect(
+  node: HTMLElement,
+  elementRects: GroupElementRectMap = {}
+): { x: number; y: number } {
   const parent = node.parentElement;
   if (!parent || !parent.hasAttribute("data-editable")) {
     return { x: 0, y: 0 };
   }
 
-  const rect = getAbsoluteNodeRect(parent);
+  const rect = getAbsoluteNodeRect(parent, elementRects);
   return { x: rect.x, y: rect.y };
 }
 
@@ -404,17 +416,21 @@ export function updateSlideElementTransform(
   });
 }
 
+// ADR-0010: Groups are nested DOM containers, not flat groupId relationships.
+// See: docs/adr/0010-represent-groups-as-nested-dom-containers.md
 export function createGroupCreateOperation({
   html,
   slideId,
   groupElementId,
   elementIds,
+  elementRects = {},
   timestamp = Date.now(),
 }: {
   html: string;
   slideId: string;
   groupElementId: string;
   elementIds: string[];
+  elementRects?: GroupElementRectMap;
   timestamp?: number;
 }): GroupCreateOperation | null {
   const doc = parseHtmlDocument(html);
@@ -449,12 +465,12 @@ export function createGroupCreateOperation({
   }
 
   const selectedGroups = selectedNodes.filter((node) => node.getAttribute("data-group") === "true");
-  const rects = uniqueNodes.map(getAbsoluteNodeRect);
+  const rects = uniqueNodes.map((node) => getAbsoluteNodeRect(node, elementRects));
   const left = Math.min(...rects.map((rect) => rect.x));
   const top = Math.min(...rects.map((rect) => rect.y));
   const right = Math.max(...rects.map((rect) => rect.x + rect.width));
   const bottom = Math.max(...rects.map((rect) => rect.y + rect.height));
-  const parentRect = getEditableAncestorRect(selectedNodes[0]);
+  const parentRect = getEditableAncestorRect(selectedNodes[0], elementRects);
   const groupNode = doc.createElement("div");
   groupNode.setAttribute("data-editable", "block");
   groupNode.setAttribute("data-group", "true");
@@ -485,7 +501,7 @@ export function createGroupCreateOperation({
   }
 
   for (const node of orderedNodes) {
-    const rect = getAbsoluteNodeRect(node);
+    const rect = getAbsoluteNodeRect(node, elementRects);
     setNodeRect(node, {
       x: rect.x - left,
       y: rect.y - top,

--- a/src/editor/components/context-menu.tsx
+++ b/src/editor/components/context-menu.tsx
@@ -17,6 +17,7 @@ import {
   Ungroup,
 } from "lucide-react";
 import type { ReactNode } from "react";
+import type { SelectionCommandAvailability } from "./floating-toolbar";
 import {
   ContextMenu,
   ContextMenuContent,
@@ -31,6 +32,7 @@ import {
 
 interface SelectionContextMenuProps {
   children: ReactNode;
+  selectionCommandAvailability: SelectionCommandAvailability;
   onAlignToSlide: (action: string) => void;
   onDelete: () => void;
   onDistribute: (action: string) => void;
@@ -42,6 +44,7 @@ interface SelectionContextMenuProps {
 
 function SelectionContextMenu({
   children,
+  selectionCommandAvailability,
   onAlignToSlide,
   onDelete,
   onDistribute,
@@ -54,11 +57,11 @@ function SelectionContextMenu({
     <ContextMenu>
       <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
       <ContextMenuContent aria-label="Selection actions">
-        <ContextMenuItem onSelect={onGroup}>
+        <ContextMenuItem disabled={!selectionCommandAvailability.group} onSelect={onGroup}>
           <Group className="size-3.5" />
           Group
         </ContextMenuItem>
-        <ContextMenuItem onSelect={onUngroup}>
+        <ContextMenuItem disabled={!selectionCommandAvailability.ungroup} onSelect={onUngroup}>
           <Ungroup className="size-3.5" />
           Ungroup
         </ContextMenuItem>

--- a/src/editor/components/floating-toolbar-feature.tsx
+++ b/src/editor/components/floating-toolbar-feature.tsx
@@ -21,12 +21,14 @@ export function renderFloatingToolbarFeature({
   feature,
   onClosePanel,
   onCommitFeature,
+  operationAvailability,
   onStyleChange,
 }: {
   currentValue: string;
   feature: ElementToolFeature;
   onClosePanel: () => void;
   onCommitFeature: (feature: ElementToolFeature, nextValue: string) => void;
+  operationAvailability?: Partial<Record<ElementToolFeature["id"], boolean>>;
   onStyleChange: (propertyName: string, nextValue: string) => void;
 }) {
   const fieldId = `floating-${feature.id}`;
@@ -126,11 +128,19 @@ export function renderFloatingToolbarFeature({
         <div className="grid gap-1">
           {(feature.options ?? []).map((option) => {
             const Icon = option.icon;
+            const disabled =
+              feature.target === "operation" && operationAvailability
+                ? operationAvailability[feature.id] === false
+                : false;
             return (
               <ToolbarOption
                 key={option.value}
+                disabled={disabled}
                 title={option.label}
                 onClick={() => {
+                  if (disabled) {
+                    return;
+                  }
                   onCommitFeature(feature, option.value);
                   onClosePanel();
                 }}

--- a/src/editor/components/floating-toolbar-parts.tsx
+++ b/src/editor/components/floating-toolbar-parts.tsx
@@ -183,10 +183,12 @@ export function ToolbarIcon({ icon: Icon }: { icon: LucideIcon }) {
 
 export function ToolbarOption({
   children,
+  disabled = false,
   onClick,
   title,
 }: {
   children: ReactNode;
+  disabled?: boolean;
   onClick: () => void;
   title?: string;
 }) {
@@ -195,6 +197,7 @@ export function ToolbarOption({
       variant="ghost"
       className="min-h-8 w-full justify-start gap-2 rounded-md px-2 py-1.5 text-left text-[13px] font-normal text-foreground/70 hover:text-foreground"
       type="button"
+      disabled={disabled}
       title={title}
       onClick={onClick}
     >

--- a/src/editor/components/floating-toolbar.tsx
+++ b/src/editor/components/floating-toolbar.tsx
@@ -31,6 +31,7 @@ import {
 interface FloatingToolbarProps {
   inspectedStyles: CssPropertyRow[];
   selectedElementType: EditableType | "multi";
+  selectionCommandAvailability: SelectionCommandAvailability;
   attributeValues: AttributeValues;
   onStyleChange: (propertyName: string, nextValue: string) => void;
   onAttributeChange: (attributeName: string, nextValue: string) => void;
@@ -48,11 +49,17 @@ interface AttributeValues {
   linkUrl: string;
 }
 
+export interface SelectionCommandAvailability {
+  group: boolean;
+  ungroup: boolean;
+}
+
 const EMPTY_SELECT_VALUE = "__empty__";
 
 function FloatingToolbar({
   inspectedStyles,
   selectedElementType,
+  selectionCommandAvailability,
   attributeValues,
   onStyleChange,
   onAttributeChange,
@@ -274,6 +281,7 @@ function FloatingToolbar({
       feature,
       onClosePanel: () => setActiveSubgroupId(null),
       onCommitFeature: commitFeature,
+      operationAvailability: selectionCommandAvailability,
       onStyleChange,
     });
   }

--- a/src/editor/components/stage-canvas.tsx
+++ b/src/editor/components/stage-canvas.tsx
@@ -4,7 +4,7 @@ import type { CssPropertyRow } from "../lib/collect-css-properties";
 import { cn } from "../lib/utils";
 import { BlockManipulationOverlay } from "./block-manipulation-overlay";
 import { SelectionContextMenu } from "./context-menu";
-import { FloatingToolbar } from "./floating-toolbar";
+import { FloatingToolbar, type SelectionCommandAvailability } from "./floating-toolbar";
 
 type ResizeHandleCorner = "top-left" | "top-right" | "bottom-right" | "bottom-left";
 
@@ -18,6 +18,8 @@ interface StageCanvasProps {
   toolbarKey: string | null;
   inspectedStyles: CssPropertyRow[];
   selectedElementType: EditableType | "multi";
+  selectionCommandAvailability: SelectionCommandAvailability;
+  groupScopeOverlayPassive: boolean;
   isEditingText: boolean;
   manipulationOverlay: {
     selectionBounds: StageRect;
@@ -50,7 +52,7 @@ interface StageCanvasProps {
     event: ReactMouseEvent<HTMLButtonElement>
   ) => void;
   onRotateHandleMouseDown: (event: ReactMouseEvent<HTMLButtonElement>) => void;
-  onSelectionOverlayDoubleClick: () => void;
+  onSelectionOverlayDoubleClick: (event: ReactMouseEvent<HTMLDivElement>) => void;
   onBackgroundClick: () => void;
   onStyleChange: (propertyName: string, nextValue: string) => void;
   onAttributeChange: (attributeName: string, nextValue: string) => void;
@@ -73,6 +75,8 @@ function StageCanvas({
   toolbarKey,
   inspectedStyles,
   selectedElementType,
+  selectionCommandAvailability,
+  groupScopeOverlayPassive,
   isEditingText,
   manipulationOverlay,
   attributeValues,
@@ -131,6 +135,7 @@ function StageCanvas({
             key={toolbarKey}
             inspectedStyles={inspectedStyles}
             selectedElementType={selectedElementType}
+            selectionCommandAvailability={selectionCommandAvailability}
             attributeValues={attributeValues}
             onStyleChange={onStyleChange}
             onAttributeChange={onAttributeChange}
@@ -169,6 +174,7 @@ function StageCanvas({
       </div>
       {selectionOverlay && !isEditingText ? (
         <SelectionContextMenu
+          selectionCommandAvailability={selectionCommandAvailability}
           onAlignToSlide={onAlignToSlide}
           onDelete={onDelete}
           onDistribute={onDistribute}
@@ -180,7 +186,10 @@ function StageCanvas({
           <div
             ref={selectionOverlayRef}
             data-testid="selection-overlay"
-            className="pointer-events-auto absolute z-[3] border border-dashed border-foreground/55 bg-foreground/[0.02]"
+            className={cn(
+              "absolute z-[3] border border-dashed border-foreground/55 bg-foreground/[0.02]",
+              groupScopeOverlayPassive ? "pointer-events-none" : "pointer-events-auto"
+            )}
             style={{
               left: `${selectionOverlay.x}px`,
               top: `${selectionOverlay.y}px`,
@@ -188,8 +197,8 @@ function StageCanvas({
               height: `${selectionOverlay.height}px`,
             }}
             onMouseDown={onSelectionOverlayMouseDown}
-            onDoubleClick={() => {
-              onSelectionOverlayDoubleClick();
+            onDoubleClick={(event) => {
+              onSelectionOverlayDoubleClick(event);
             }}
           />
         </SelectionContextMenu>

--- a/src/editor/index.tsx
+++ b/src/editor/index.tsx
@@ -6,6 +6,7 @@ import {
   type ElementInsertOperation,
   type ElementLayoutUpdateOperation,
   type ElementRemoveOperation,
+  type GroupElementRectMap,
   SELECTOR_ATTR,
   type SlideModel,
   type StyleUpdateOperation,
@@ -95,6 +96,19 @@ function SlidesEditor({
     selectedElementIds.length > 1
       ? "multi"
       : (selectedElement?.type ?? activeGroupScopeElement?.type ?? "block");
+  const selectedElements = activeSlide
+    ? selectedElementIds
+        .map((elementId) => activeSlide.elements.find((element) => element.id === elementId))
+        .filter((element): element is SlideModel["elements"][number] => Boolean(element))
+    : [];
+  const selectionCommandAvailability = {
+    group: selectedElementIds.length >= 2 && selectedElements.length === selectedElementIds.length,
+    ungroup: selectedElementIds.length === 1 && selectedElement?.type === "group",
+  };
+  const groupScopeOverlayPassive =
+    Boolean(activeGroupScopeId) &&
+    selectedElementIds.length === 1 &&
+    selectedElementId === activeGroupScopeId;
   const resolvedDeckTitle = deckTitle?.trim() || "Untitled deck";
 
   const slideWidth = activeSlide?.width || DEFAULT_SLIDE_WIDTH;
@@ -340,11 +354,13 @@ function SlidesEditor({
       return;
     }
 
+    const elementRects = createGroupElementRectMap();
     const groupElementId = createUniqueElementId(activeSlide.htmlSource, "group-1");
     const operation = createGroupCreateOperation({
       html: activeSlide.htmlSource,
       slideId: activeSlide.id,
       groupElementId,
+      elementRects,
       elementIds: selectedElementIds,
     });
 
@@ -352,6 +368,44 @@ function SlidesEditor({
       commitOperation(operation);
       setSelectedElementIds([groupElementId]);
     }
+  }
+
+  function createGroupElementRectMap(): GroupElementRectMap {
+    const doc = iframeRef.current?.contentDocument;
+    const root = doc?.querySelector<HTMLElement>(activeSlide?.rootSelector ?? "");
+    if (!doc || !root) {
+      return {};
+    }
+
+    const rootRect = root.getBoundingClientRect();
+    const scaleX = activeSlide ? activeSlide.width / rootRect.width : 1;
+    const scaleY = activeSlide ? activeSlide.height / rootRect.height : 1;
+    const rects: GroupElementRectMap = {};
+    for (const node of doc.querySelectorAll<HTMLElement>(`[data-editable][${SELECTOR_ATTR}]`)) {
+      const elementId = node.getAttribute(SELECTOR_ATTR);
+      if (!elementId) {
+        continue;
+      }
+
+      const rect = node.getBoundingClientRect();
+      const parent = node.parentElement;
+      const parentId =
+        parent?.hasAttribute("data-editable") && parent.getAttribute(SELECTOR_ATTR)
+          ? parent.getAttribute(SELECTOR_ATTR)
+          : null;
+      const parentRect = parentId
+        ? (rects[parentId] ?? { x: 0, y: 0, width: rootRect.width, height: rootRect.height })
+        : { x: 0, y: 0, width: rootRect.width, height: rootRect.height };
+
+      rects[elementId] = {
+        x: (rect.left - rootRect.left) * scaleX - parentRect.x,
+        y: (rect.top - rootRect.top) * scaleY - parentRect.y,
+        width: rect.width * scaleX,
+        height: rect.height * scaleY,
+      };
+    }
+
+    return rects;
   }
 
   function ungroupSelection() {
@@ -551,6 +605,8 @@ function SlidesEditor({
               }
               inspectedStyles={inspectedStyles}
               selectedElementType={selectedElementType}
+              selectionCommandAvailability={selectionCommandAvailability}
+              groupScopeOverlayPassive={groupScopeOverlayPassive}
               isEditingText={isEditingText}
               manipulationOverlay={manipulationOverlay}
               iframeRef={iframeRef}
@@ -593,7 +649,27 @@ function SlidesEditor({
                   stopPropagation: () => event.stopPropagation(),
                 });
               }}
-              onSelectionOverlayDoubleClick={() => {
+              onSelectionOverlayDoubleClick={(event) => {
+                if (activeGroupScopeId && iframeRef.current?.contentDocument) {
+                  const iframeRect = iframeRef.current.getBoundingClientRect();
+                  const doc = iframeRef.current.contentDocument;
+                  const scopedTarget = doc.elementFromPoint(
+                    event.clientX - iframeRect.left,
+                    event.clientY - iframeRect.top
+                  );
+                  const scopedEditable = scopedTarget?.closest<HTMLElement>(
+                    `[data-editable][${SELECTOR_ATTR}]`
+                  );
+
+                  if (scopedEditable?.getAttribute("data-editable") === "text") {
+                    const scopedElementId = scopedEditable.getAttribute(SELECTOR_ATTR);
+                    if (scopedElementId) {
+                      beginTextEditing(scopedElementId);
+                      return;
+                    }
+                  }
+                }
+
                 if (
                   selectedElementIds.length === 1 &&
                   selectedElement?.type === "text" &&


### PR DESCRIPTION
## Summary
- 落实 ADR 10 的 group 交互与数据模型：补齐 group create / ungroup 的回归测试、Flatten and Group 相关几何写回、跨父层拒绝和普通 block 不可 ungroup 的约束
- 让 `Group` / `Ungroup` 在工具栏和右键菜单里按选择状态禁用，避免无效操作只靠核心层兜底
- 修复 Group Editing Scope 下的双击与点击命中，让组内文本编辑和组内选择在 scope 中可用
- 为 group 相关核心入口补了 `ADR-0010` 代码引用，并同步更新 regression deck 相关测试期望

## Testing
- `pnpm lint`
- `pnpm build:types`
- `pnpm test -- src/core/slide-document.test.ts src/core/slide-operations.test.ts src/core/slide-operation-reducer.test.ts src/core/generated-deck.test.ts`
- `pnpm test:e2e -- e2e/tests/floating-toolbar.spec.ts e2e/tests/block-manipulation.spec.ts`