### PR TITLE
Refine the thumbnail sidebar UI and document follow-up slide operations

### DIFF
--- a/docs/adr/0016-adopt-pdf-export-pipeline-through-core-runtime-cli-and-editor.md
+++ b/docs/adr/0016-adopt-pdf-export-pipeline-through-core-runtime-cli-and-editor.md
@@ -1,0 +1,117 @@
+# ADR-0016: Adopt a PDF export pipeline through core, runtime, CLI, and editor entry points
+
+- Status: accepted
+- Date: 2026-05-07
+
+## Context
+
+Starry Slides already has a browser-rendered preview pipeline in
+`src/runtime/view-renderer.ts` and an editor header export menu placeholder in
+`src/editor/components/editor-header.tsx`. The product now needs a real PDF
+export path that can be triggered from both the CLI and the editor UI.
+
+The export behavior must support three entry-level modes:
+
+- export a single slide
+- export the whole deck
+- export a selected subset of slides
+
+The implementation must keep shared decision logic in `src/core`, because the
+export mode and slide selection semantics are part of the product contract, not
+just UI behavior. The browser-side editor cannot create PDFs directly; the PDF
+must be produced by Node runtime code that can launch Chromium and call
+`page.pdf()`.
+
+Existing architecture constraints:
+
+- `src/core` must stay browser-safe and cannot depend on `src/runtime`
+- `src/runtime` may depend on `src/core` for contract-aware helpers
+- the CLI must remain agent-facing and machine-readable by default
+- the editor header should trigger the same export pipeline, not a separate
+  implementation
+
+## Decision
+
+Introduce a shared PDF export pipeline with the following structure:
+
+1. `src/core` owns PDF export planning and slide-selection resolution.
+   It exposes a small browser-safe API that resolves which slides belong in a
+   PDF export request and validates the selection shape.
+2. `src/runtime` owns the actual PDF generation. It loads slide HTML from a deck
+   package, renders the selected slides in Chromium, and writes a PDF file or
+   returns PDF bytes.
+3. `src/cli` adds `starry-slides export pdf ...` as the agent-facing command
+   surface for PDF export.
+4. `src/editor` adds an export control in the header that calls a local Vite
+   middleware endpoint, which reuses the same runtime exporter used by the CLI.
+
+The export command shape is:
+
+```bash
+starry-slides export pdf [deck] --out <file>
+starry-slides export pdf [deck] --all --out <file>
+starry-slides export pdf [deck] --slide <manifest-file> --out <file>
+starry-slides export pdf [deck] --slides <manifest-file> --out <file>
+```
+
+The editor entry point uses the same selection model, but it sends the request
+to a local server endpoint instead of spawning a separate process.
+
+The PDF exporter must preserve slide order from the manifest and must reject
+slide references that do not match exact manifest `file` values.
+
+## Consequences
+
+- CLI and editor exports share one contract for slide selection and output
+  layout.
+- The export logic becomes testable at three layers: core selection rules,
+  runtime PDF generation, and CLI/editor entry points.
+- The editor export path depends on the Vite middleware runtime, so it works in
+  local development and preview, not as a standalone browser-only action.
+- Future export formats can reuse the same core selection model.
+
+## Alternatives considered
+
+- Put all export logic in the CLI. Rejected because the editor would duplicate
+  selection rules.
+- Generate PDFs in the browser. Rejected because the browser app cannot safely
+  own the Chromium/PDF dependency or write files directly.
+- Keep single-slide export only. Rejected because the product now needs both
+  single and deck-level export modes.
+
+## Implementation Plan
+
+- **Affected paths**:
+  - `src/core/pdf-export.ts` or equivalent new core module
+  - `src/core/index.ts`
+  - `src/runtime/pdf-export.ts` or equivalent new runtime module
+  - `src/runtime/view-renderer.ts` if shared Chromium helpers are reused
+  - `src/cli/index.ts`
+  - `src/cli/index.test.ts`
+  - `src/runtime/view-renderer.test.ts` or a new runtime PDF test file
+  - `src/editor/components/editor-header.tsx`
+  - `src/editor/app/use-slides-data.ts`
+  - `vite.config.ts`
+  - `docs/adr/README.md`
+
+- **Pattern**:
+  - use a core-owned selection resolver for `all`, `single slide`, and `selected slide files`
+  - keep PDF generation in runtime and use Chromium `page.pdf()`
+  - return machine-readable results from CLI commands and a binary PDF response from the editor endpoint
+  - keep the editor header as a trigger only; it must not implement PDF generation itself
+
+- **Tests**:
+  - core tests cover selection resolution and manifest-file validation
+  - runtime tests cover PDF generation output and selection order
+  - CLI tests cover `export pdf` command parsing, JSON/file side effects, and exit codes
+  - editor tests cover the export trigger path and the middleware endpoint contract
+
+## Verification
+
+- [ ] `starry-slides export pdf ...` writes a valid PDF file for a single slide
+- [ ] `starry-slides export pdf ... --all` exports every manifest slide in order
+- [ ] `starry-slides export pdf ... --slide <manifest-file>` exports exactly one slide
+- [ ] `starry-slides export pdf ... --slides <manifest-file>` exports the requested subset in order
+- [ ] the editor header can trigger the same export pipeline through the local runtime endpoint
+- [ ] the exported PDF bytes begin with the PDF header and the output file is non-empty
+- [ ] CLI and editor export behavior remain stable under automated tests

--- a/docs/adr/0017-adopt-deck-level-slide-operations-for-thumbnail-sidebar.md
+++ b/docs/adr/0017-adopt-deck-level-slide-operations-for-thumbnail-sidebar.md
@@ -1,0 +1,185 @@
+# ADR-0017: Adopt deck-level slide operations for the thumbnail sidebar
+
+- Status: proposed
+- Date: 2026-05-07
+
+## Context
+
+The editor sidebar has been restyled as a fixed thumbnail list with controls for
+adding slides, duplicating slides, deleting slides, hiding slides, and drag
+reordering. The first implementation intentionally ships the UI affordances
+without enabling the new deck-level behavior.
+
+The current editor operation pipeline is element-scoped:
+
+- `src/core/slide-operation-types.ts` defines operations inside a single slide.
+- `src/core/slide-operation-reducer.ts` applies operations by matching
+  `slideId`.
+- `src/core/history.ts` maps those operations over an existing slide array.
+- `src/editor/hooks/use-slide-history.ts` owns active slide selection, undo, and
+  redo for element changes.
+- `src/editor/app/use-slides-data.ts` saves edited slide HTML back to existing
+  manifest files.
+
+That model is not enough for sidebar-level actions because those actions change
+the deck as a collection. They need to create, remove, reorder, and mark slides
+in ways that must survive save/reload and stay compatible with the deck
+manifest.
+
+Related constraints:
+
+- ADR-0001 keeps editing as explicit operations with local history.
+- ADR-0007 limits generated deck copies and favors editing the active deck
+  package in place.
+- ADR-0011 makes the CLI/deck package contract agent-facing.
+- ADR-0015 keeps editor chrome compact and neutral; the new sidebar UI follows
+  that visual direction.
+
+## Decision
+
+Adopt deck-level slide operations before wiring the new sidebar controls to real
+behavior.
+
+Deck-level operations will live alongside element operations but operate on the
+slide collection:
+
+- `slide.create`
+- `slide.duplicate`
+- `slide.delete`
+- `slide.reorder`
+- `slide.visibility.update`
+
+The operation model must keep these concerns explicit:
+
+1. **Collection order**: the slide array order is the source of editor ordering.
+2. **Manifest persistence**: save/reload must preserve order and visibility.
+3. **Source files**: newly created or duplicated slides need deterministic
+   `sourceFile` assignment before save.
+4. **Undo/redo**: deck-level actions must use the same local history surface as
+   element edits.
+5. **Active slide behavior**: deleting, duplicating, or reordering slides must
+   leave `activeSlideId` pointing at a valid slide.
+
+Slide visibility will be stored as manifest metadata, not only in memory. The
+manifest entry should grow an optional `hidden?: boolean` field, and
+`SlideModel` should expose the same optional flag after import. Hidden slides
+remain editable in the editor unless a later ADR decides otherwise; the first
+meaningful behavior is that presentation/export paths can skip hidden slides
+when they use the deck presentation order.
+
+Drag reordering should be implemented as a normal operation that records the
+previous and next index. The sidebar grip remains only a UI handle until that
+operation exists.
+
+## Implementation Plan
+
+- **Affected paths**:
+  - `src/core/slide-contract.ts`
+  - `src/core/slide-operation-types.ts`
+  - `src/core/slide-operation-reducer.ts`
+  - `src/core/history.ts`
+  - `src/core/generated-deck.ts`
+  - `src/core/verify-deck.ts`
+  - `src/editor/hooks/use-slide-history.ts`
+  - `src/editor/components/slide-sidebar.tsx`
+  - `src/editor/app/use-slides-data.ts`
+  - `vite.config.ts`
+  - `src/runtime/view-renderer.ts`
+  - `src/cli/index.ts`
+  - relevant unit and e2e tests under `src/**.test.ts` and `e2e/tests/`
+
+- **Operation shape**:
+  - add a deck operation union separate from atomic slide-element operations
+  - update history reduction to apply either element operations or deck
+    operations
+  - keep element operations targeted by `slideId`
+  - keep deck operations targeted at the collection and do not overload
+    `slideId`
+
+- **Persistence pattern**:
+  - preserve existing `sourceFile` values for loaded slides
+  - generate deterministic files for new slides, for example under
+    `slides/<next-number>-untitled.html`
+  - when duplicating a slide, copy `htmlSource`, assign a new `id`, assign a new
+    `sourceFile`, and preserve the title unless the UI later asks to rename it
+  - extend editor save payloads so the server can update both slide files and
+    `manifest.json`
+  - keep missing or legacy `hidden` values equivalent to `false`
+
+- **Sidebar wiring**:
+  - `onAdd` dispatches `slide.create`
+  - `onDuplicate` dispatches `slide.duplicate`
+  - `onDelete` dispatches `slide.delete`
+  - `onToggleHidden` dispatches `slide.visibility.update`
+  - drag-and-drop dispatches `slide.reorder`
+  - destructive delete should be disabled or guarded when only one slide remains
+
+- **Tests**:
+  - core tests cover create, duplicate, delete, reorder, visibility, undo, and
+    redo
+  - generated deck tests cover manifest import/export of `hidden`
+  - editor tests cover sidebar controls, active slide fallback after delete,
+    scroll-to-active behavior, and no-op behavior while controls are still
+    intentionally unwired
+  - runtime/CLI tests cover presentation/export behavior for hidden slides once
+    those consumers adopt visibility semantics
+
+## Verification
+
+- [ ] Adding a slide creates a new `SlideModel`, a deterministic `sourceFile`,
+      and a manifest entry on save.
+- [ ] Duplicating a slide creates a new slide with copied HTML, unique editor
+      ids where needed, and a unique `sourceFile`.
+- [ ] Deleting a slide removes it from editor state and from the saved
+      manifest, while leaving at least one active slide.
+- [ ] Reordering slides updates editor order, saved manifest order, and undo/redo
+      state.
+- [ ] Toggling hidden updates `SlideModel.hidden` and `manifest.slides[].hidden`.
+- [ ] Legacy manifests without `hidden` continue to load as visible slides.
+- [ ] Sidebar controls call real deck operations only after the core operation
+      model exists.
+- [ ] `pnpm lint`, `pnpm test`, `pnpm build`, and relevant e2e tests pass after
+      implementation.
+
+## Consequences
+
+The sidebar UI can ship before these capabilities are implemented, but future
+agents have a precise contract for wiring the controls.
+
+The history reducer becomes responsible for both element-level and deck-level
+operations. That raises the importance of keeping operation types explicit and
+well tested.
+
+Saving can no longer treat the manifest as immutable once these operations
+exist. The editor save endpoint must update `manifest.json` as well as slide
+HTML files.
+
+Presentation and export paths gain a shared visibility concept, but hidden-slide
+semantics should be adopted deliberately by each consumer instead of being
+silently inferred in unrelated code.
+
+## Alternatives considered
+
+### Keep sidebar actions as local React state
+
+Rejected. Local-only state would not survive save/reload, would not fit the
+existing undo/redo model, and would make future CLI/runtime behavior diverge
+from the editor.
+
+### Implement each sidebar action directly in `SlidesEditor`
+
+Rejected. Direct array mutation inside the editor would bypass the operation
+pipeline established by ADR-0001 and would make tests harder to share across
+core, editor, and runtime consumers.
+
+### Store hidden slides only in slide HTML
+
+Rejected. Visibility is deck metadata, not slide content. Putting it only in the
+HTML would make ordering/export decisions parse every slide file and would blur
+the boundary between generated slide content and deck presentation metadata.
+
+### Delay the UI until every capability exists
+
+Rejected. The product can adopt the target sidebar chrome first. The inactive
+controls are acceptable while the ADR records the implementation contract for
+the missing behavior.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -45,3 +45,5 @@ Update this directory whenever a change affects:
 | [0013](./0013-adopt-editing-e2e-coverage-contract.md)              | Adopt editing E2E coverage contract                                      | proposed   |
 | [0014](./0014-adopt-cli-and-core-verification-test-contract.md)     | Adopt CLI and core verification test contract                            | proposed   |
 | [0015](./0015-adopt-minimal-mono-editor-chrome-direction.md)        | Adopt Minimal Mono editor chrome direction                               | implemented-reference |
+| [0016](./0016-adopt-pdf-export-pipeline-through-core-runtime-cli-and-editor.md) | Adopt a PDF export pipeline through core, runtime, CLI, and editor entry points | accepted   |
+| [0017](./0017-adopt-deck-level-slide-operations-for-thumbnail-sidebar.md) | Adopt deck-level slide operations for the thumbnail sidebar              | proposed   |

--- a/e2e/tests/editor-chrome.spec.ts
+++ b/e2e/tests/editor-chrome.spec.ts
@@ -35,28 +35,20 @@ test("selecting another element after clearing selection keeps the app mounted",
   expect(pageErrors).toEqual([]);
 });
 
-test("sidebar scrolls with overflow and expands on hover without shifting the stage", async ({
-  page,
-}) => {
+test("sidebar renders fixed thumbnail list chrome and slide actions", async ({ page }) => {
   await gotoEditor(page);
 
   const sidebar = page.getByTestId("slide-sidebar");
   const sidebarPanel = page.getByTestId("slide-sidebar-panel");
-  const slideList = page
-    .getByTestId("slide-list")
-    .locator('[data-slot="scroll-area-viewport"]')
-    .first();
+  const slideList = page.getByTestId("slide-list");
   const stagePanel = page.getByTestId("stage-panel");
 
   await expect(sidebar).toBeVisible();
   await expect(sidebarPanel).toBeVisible();
+  await expect(page.getByText("14 slides")).toBeVisible();
+  await expect(page.getByRole("button", { name: "Add slide" })).toBeVisible();
 
-  const collapsedSidebarWidth = await sidebar.evaluate(
-    (node) => node.getBoundingClientRect().width
-  );
-  const collapsedPanelWidth = await sidebarPanel.evaluate(
-    (node) => node.getBoundingClientRect().width
-  );
+  const sidebarWidth = await sidebar.evaluate((node) => node.getBoundingClientRect().width);
   const stageWidthBeforeHover = await stagePanel.evaluate(
     (node) => node.getBoundingClientRect().width
   );
@@ -67,26 +59,20 @@ test("sidebar scrolls with overflow and expands on hover without shifting the st
   }));
 
   expect(["auto", "scroll"]).toContain(overflowState.overflowY);
+  expect(sidebarWidth).toBeGreaterThanOrEqual(210);
+  expect(sidebarWidth).toBeLessThanOrEqual(214);
 
   await sidebar.hover();
 
-  await expect
-    .poll(async () => {
-      return sidebar.evaluate((node) => node.getBoundingClientRect().width);
-    })
-    .toBeGreaterThan(collapsedSidebarWidth + 20);
-
-  const expandedSidebarWidth = await sidebar.evaluate((node) => node.getBoundingClientRect().width);
-  const expandedPanelWidth = await sidebarPanel.evaluate(
+  const sidebarWidthAfterHover = await sidebar.evaluate(
     (node) => node.getBoundingClientRect().width
   );
   const stageWidthAfterHover = await stagePanel.evaluate(
     (node) => node.getBoundingClientRect().width
   );
 
-  expect(expandedSidebarWidth).toBeGreaterThan(collapsedSidebarWidth + 20);
-  expect(expandedPanelWidth).toBeGreaterThan(collapsedPanelWidth + 20);
-  expect(stageWidthAfterHover).toBeLessThan(stageWidthBeforeHover - 20);
+  expect(sidebarWidthAfterHover).toBe(sidebarWidth);
+  expect(stageWidthAfterHover).toBe(stageWidthBeforeHover);
 
   const slideTwoButton = page.getByLabel("Slide 2");
   await slideTwoButton.click();
@@ -104,9 +90,17 @@ test("sidebar scrolls with overflow and expands on hover without shifting the st
       });
     })
     .not.toEqual({
-      borderTopWidth: "2px",
+      borderTopWidth: "0px",
       borderTopColor: "rgba(0, 0, 0, 0)",
     });
+
+  const slideTwoCard = page.getByTestId("slide-card").nth(1);
+  await slideTwoCard.hover();
+  await expect(slideTwoCard.getByRole("button", { name: "Drag to reorder" })).toBeVisible();
+  await slideTwoCard.locator('button[aria-haspopup="menu"]').click();
+  await expect(page.getByRole("button", { name: "Duplicate" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Hide" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Delete" })).toBeVisible();
 
   if (overflowState.scrollHeight > overflowState.clientHeight) {
     await page.getByLabel("Slide 8").click();

--- a/src/core/pdf-export.test.ts
+++ b/src/core/pdf-export.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "vitest";
+import { planPdfExportSlides } from "./index";
+
+const manifestSlides = [
+  { file: "slides/01.html", title: "One" },
+  { file: "slides/02.html", title: "Two" },
+  { file: "slides/03.html", title: "Three" },
+];
+
+describe("PDF export planning", () => {
+  test("defaults to every manifest slide in order", () => {
+    expect(planPdfExportSlides(manifestSlides)).toEqual(manifestSlides);
+    expect(planPdfExportSlides(manifestSlides, { mode: "all" })).toEqual(manifestSlides);
+  });
+
+  test("resolves a single manifest slide file exactly", () => {
+    expect(planPdfExportSlides(manifestSlides, { mode: "slide", slideFile: "slides/02.html" })).toEqual([
+      manifestSlides[1],
+    ]);
+  });
+
+  test("resolves selected manifest slide files in requested order", () => {
+    expect(
+      planPdfExportSlides(manifestSlides, {
+        mode: "slides",
+        slideFiles: ["slides/03.html", "slides/01.html"],
+      })
+    ).toEqual([manifestSlides[2], manifestSlides[0]]);
+  });
+
+  test("rejects missing or non-exact slide selections", () => {
+    expect(() => planPdfExportSlides(manifestSlides, { mode: "slide" })).toThrow(
+      "--slide requires a manifest slide file value"
+    );
+    expect(() =>
+      planPdfExportSlides(manifestSlides, { mode: "slide", slideFile: "2" })
+    ).toThrow("--slide must match a manifest slide file exactly: 2");
+    expect(() =>
+      planPdfExportSlides(manifestSlides, {
+        mode: "slides",
+        slideFiles: ["slides/01.html", "missing.html"],
+      })
+    ).toThrow("--slides must match manifest slide files exactly: missing.html");
+  });
+});

--- a/src/editor/components/slide-sidebar.tsx
+++ b/src/editor/components/slide-sidebar.tsx
@@ -1,7 +1,16 @@
-import { useCallback } from "react";
+import {
+  Copy,
+  Eye,
+  EyeOff,
+  GripVertical,
+  type LucideIcon,
+  MoreHorizontal,
+  Plus,
+  Trash2,
+} from "lucide-react";
+import { useCallback, useState } from "react";
 import type { SlideModel } from "../../core";
 import { cn } from "../lib/utils";
-import { ScrollArea } from "./ui/scroll-area";
 
 interface SlideSidebarProps {
   slides: SlideModel[];
@@ -9,6 +18,17 @@ interface SlideSidebarProps {
   slideCount: number;
   thumbnails: Record<string, string>;
   onSelectSlide: (slideId: string) => void;
+  onAdd?: () => void;
+  onDuplicate?: (slideId: string) => void;
+  onDelete?: (slideId: string) => void;
+  onToggleHidden?: (slideId: string) => void;
+}
+
+interface MenuItemProps {
+  icon: LucideIcon;
+  label: string;
+  onClick: () => void;
+  danger?: boolean;
 }
 
 function SlideSidebar({
@@ -17,7 +37,14 @@ function SlideSidebar({
   slideCount,
   thumbnails,
   onSelectSlide,
+  onAdd,
+  onDuplicate,
+  onDelete,
+  onToggleHidden,
 }: SlideSidebarProps) {
+  const [menuId, setMenuId] = useState<string | null>(null);
+  const [hoverId, setHoverId] = useState<string | null>(null);
+
   const activeSlideRef = useCallback((node: HTMLButtonElement | null) => {
     node?.scrollIntoView({
       block: "nearest",
@@ -27,79 +54,187 @@ function SlideSidebar({
 
   return (
     <aside
-      className="group/sidebar relative flex min-h-0 min-w-0 basis-[124px] items-stretch justify-start overflow-hidden bg-transparent p-3 transition-[flex-basis,width,opacity] duration-200 ease-out after:absolute after:inset-y-1.5 after:right-0 after:w-px after:bg-foreground/10 hover:basis-[260px] focus-within:basis-[260px] max-[1200px]:basis-auto max-[1200px]:p-0 max-[1200px]:pb-2.5 max-[1200px]:after:inset-x-0 max-[1200px]:after:inset-y-auto max-[1200px]:after:bottom-0 max-[1200px]:after:h-px max-[1200px]:after:w-auto"
+      className="flex h-[calc(100vh-3.5rem)] w-[212px] shrink-0 flex-col border-r border-foreground/[0.06] bg-white"
       data-testid="slide-sidebar"
     >
       <div
-        className="flex h-full min-h-0 w-full min-w-0 flex-col gap-2.5"
+        className="flex h-full min-h-0 w-full min-w-0 flex-col"
         data-testid="slide-sidebar-panel"
       >
-        <div className="flex min-h-7 items-center pt-1">
-          <span
-            className="inline-block text-[10px] font-medium uppercase tracking-wider text-foreground/40"
+        <div className="flex h-10 items-center justify-between border-b border-foreground/[0.06] px-3">
+          <div
+            className="text-[11px] font-medium uppercase tracking-wider text-foreground/50"
             data-testid="slide-count"
           >
-            {slideCount} slide{slideCount === 1 ? "" : "s"}
-          </span>
+            <span className="tabular-nums">{slideCount}</span> slides
+          </div>
+          <button
+            onClick={onAdd}
+            className="flex size-7 items-center justify-center rounded-md text-foreground/50 transition-colors hover:bg-foreground/[0.06] hover:text-foreground"
+            type="button"
+            title="Add slide"
+            aria-label="Add slide"
+          >
+            <Plus className="size-3.5" />
+          </button>
         </div>
-        <ScrollArea
-          className="min-h-0 flex-1 overflow-hidden pt-2 [mask-image:linear-gradient(to_bottom,transparent_0,black_18px,black_calc(100%_-_18px),transparent_100%)]"
+
+        <div
+          className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-2 py-2.5"
           data-testid="slide-list"
         >
-          <div className="grid content-start gap-2.5 pr-2 transition-[gap] duration-150 group-[:not(:hover):not(:focus-within)]/sidebar:gap-2">
-            {slides.map((slide, index) => (
-              <button
+          {slides.map((slide, index) => {
+            const active = slide.id === activeSlideId;
+            const hidden = false;
+
+            return (
+              <div
                 key={slide.id}
-                ref={slide.id === activeSlideId ? activeSlideRef : null}
-                className={cn(
-                  "grid w-full cursor-pointer gap-2 border-0 bg-transparent p-0 text-left opacity-100 transition-opacity duration-150 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
-                  slide.id !== activeSlideId &&
-                    "group-[:not(:hover):not(:focus-within)]/sidebar:opacity-90"
-                )}
-                onClick={() => onSelectSlide(slide.id)}
-                type="button"
-                aria-label={`Slide ${index + 1}`}
-                aria-current={slide.id === activeSlideId ? "true" : undefined}
+                onMouseEnter={() => setHoverId(slide.id)}
+                onMouseLeave={() => {
+                  setHoverId(null);
+                  if (menuId === slide.id) {
+                    setMenuId(null);
+                  }
+                }}
+                className="group flex items-stretch gap-1.5"
                 data-testid="slide-card"
               >
                 <div
                   className={cn(
-                    "relative aspect-video w-full overflow-hidden rounded-xl border border-foreground/[0.08] bg-white transition-[border-color,box-shadow,border-radius] duration-150 group-[:not(:hover):not(:focus-within)]/sidebar:rounded-lg",
-                    slide.id === activeSlideId &&
-                      "border-foreground/25 shadow-[0_0_0_2px_rgba(255,255,255,0.9),0_0_0_4px_rgba(0,0,0,0.08)]"
+                    "flex w-5 items-start justify-center pt-2 text-[11px] font-semibold tabular-nums transition-colors",
+                    active ? "text-foreground" : "text-foreground/55 group-hover:text-foreground/75"
                   )}
-                  data-testid="slide-thumbnail"
                 >
-                  {thumbnails[slide.id] ? (
-                    <img
-                      alt={`Slide ${index + 1}`}
-                      className={cn(
-                        "block size-full bg-transparent object-cover",
-                        slide.id === activeSlideId && "shadow-[inset_0_0_0_1px_rgba(0,0,0,0.08)]"
-                      )}
-                      src={thumbnails[slide.id]}
-                    />
-                  ) : (
-                    <div
-                      className={cn(
-                        "grid size-full place-items-center bg-foreground/[0.03]",
-                        slide.id === activeSlideId && "shadow-[inset_0_0_0_1px_rgba(0,0,0,0.08)]"
-                      )}
-                      aria-hidden="true"
-                    >
-                      <span className="size-[18px] animate-spin rounded-full border-[1.5px] border-foreground/15 border-t-foreground/45" />
-                    </div>
-                  )}
-                  <span className="pointer-events-none absolute right-2 top-2 rounded-md bg-foreground/65 px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-background opacity-0 transition-opacity duration-150 group-hover/sidebar:opacity-100 group-focus-within/sidebar:opacity-100">
-                    {index + 1}
-                  </span>
+                  {index + 1}
                 </div>
-              </button>
-            ))}
-          </div>
-        </ScrollArea>
+
+                <button
+                  ref={active ? activeSlideRef : null}
+                  className={cn(
+                    "relative flex-1 overflow-hidden rounded-lg text-left ring-1 ring-inset transition-all focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-ring",
+                    active
+                      ? "shadow-[0_0_0_2px_var(--background),0_0_0_3px_var(--foreground)] ring-foreground"
+                      : "ring-foreground/[0.08] hover:ring-foreground/20",
+                    hidden && "opacity-40"
+                  )}
+                  onClick={() => onSelectSlide(slide.id)}
+                  type="button"
+                  aria-label={`Slide ${index + 1}`}
+                  aria-current={active ? "true" : undefined}
+                >
+                  <div
+                    className="relative aspect-[16/9] w-full bg-white"
+                    data-testid="slide-thumbnail"
+                  >
+                    {thumbnails[slide.id] ? (
+                      <img
+                        alt={`Slide ${index + 1}`}
+                        className="absolute inset-0 block size-full object-cover"
+                        src={thumbnails[slide.id]}
+                      />
+                    ) : (
+                      <div className="absolute inset-0 flex items-center justify-center text-[10px] text-foreground/20">
+                        Slide {index + 1}
+                      </div>
+                    )}
+
+                    {hidden ? (
+                      <div className="absolute left-1 top-1 flex size-4 items-center justify-center rounded bg-foreground/80 text-background">
+                        <EyeOff className="size-2.5" />
+                      </div>
+                    ) : null}
+                  </div>
+
+                  {slide.title ? (
+                    <div className="truncate border-t border-foreground/[0.04] bg-white px-2 py-1 text-[11px] text-foreground/60">
+                      {slide.title}
+                    </div>
+                  ) : null}
+                </button>
+
+                <div
+                  className={cn(
+                    "flex w-5 flex-col items-center justify-start gap-0.5 pt-1.5 opacity-0 transition-opacity",
+                    (hoverId === slide.id || menuId === slide.id) && "opacity-100"
+                  )}
+                >
+                  <button
+                    className="flex size-5 cursor-grab items-center justify-center rounded text-foreground/40 hover:bg-foreground/[0.06] hover:text-foreground/80"
+                    title="Drag to reorder"
+                    type="button"
+                  >
+                    <GripVertical className="size-3" />
+                  </button>
+                  <div className="relative">
+                    <button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        setMenuId(menuId === slide.id ? null : slide.id);
+                      }}
+                      className="flex size-5 items-center justify-center rounded text-foreground/40 hover:bg-foreground/[0.06] hover:text-foreground/80"
+                      type="button"
+                      aria-haspopup="menu"
+                      aria-expanded={menuId === slide.id}
+                    >
+                      <MoreHorizontal className="size-3" />
+                    </button>
+
+                    {menuId === slide.id ? (
+                      <div className="absolute right-0 z-50 mt-1 w-32 animate-fade-in rounded-lg border border-foreground/[0.08] bg-white p-1 shadow-[0_4px_20px_rgba(0,0,0,0.06),0_12px_40px_rgba(0,0,0,0.08)]">
+                        <MenuItem
+                          icon={Copy}
+                          label="Duplicate"
+                          onClick={() => {
+                            onDuplicate?.(slide.id);
+                            setMenuId(null);
+                          }}
+                        />
+                        <MenuItem
+                          icon={hidden ? Eye : EyeOff}
+                          label={hidden ? "Show" : "Hide"}
+                          onClick={() => {
+                            onToggleHidden?.(slide.id);
+                            setMenuId(null);
+                          }}
+                        />
+                        <MenuItem
+                          icon={Trash2}
+                          label="Delete"
+                          danger
+                          onClick={() => {
+                            onDelete?.(slide.id);
+                            setMenuId(null);
+                          }}
+                        />
+                      </div>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </aside>
+  );
+}
+
+function MenuItem({ icon: Icon, label, onClick, danger }: MenuItemProps) {
+  return (
+    <button
+      onClick={onClick}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-[12px] transition-colors",
+        danger
+          ? "text-foreground/70 hover:bg-destructive/10 hover:text-destructive"
+          : "text-foreground/70 hover:bg-foreground/[0.04] hover:text-foreground"
+      )}
+      type="button"
+    >
+      <Icon className="size-3" />
+      <span>{label}</span>
+    </button>
   );
 }
 


### PR DESCRIPTION
## Summary
- Refined the thumbnail sidebar layout to match the requested chrome changes.
- Moved the add-slide control into the sidebar header, kept slide count on the left, and widened spacing between thumbnails.
- Adjusted the page-number styling for better contrast and kept the sidebar copy in English.
- Updated the editor chrome Playwright coverage to match the new layout and labels.
- Added ADRs for the PDF export pipeline and the future deck-level slide operations needed by the sidebar actions.

## Testing
- `pnpm exec biome check` on the modified UI and test files passed.
- `pnpm build` passed.
- Playwright coverage was updated for the new sidebar chrome; full e2e still has unrelated existing deck-loader/test-workflow issues outside this change.