### PR TITLE
fix(ci): remove GitHub App dependency

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -18,18 +18,10 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync to latest main
         run: |
@@ -101,7 +93,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add package.json pnpm-lock.yaml
           git commit -m "chore(release): v${{ steps.release.outputs.version }}"
-          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
           git push origin HEAD:main
 
       - name: Publish package


### PR DESCRIPTION
Remove GitHub App token generation step and use default GITHUB_TOKEN for checkout and push.

The workflow already has anti-loop logic: if the latest commit is `chore(release):*` and the version is already on npm, it skips publishing. So GITHUB_TOKEN triggering a re-run is safe.