### PR TITLE
添加 PR 级 GitHub CI E2E 门禁并跳过纯文档变更

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -1,0 +1,119 @@
+name: PR E2E Gate
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-e2e-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  changes:
+    name: Detect changed files
+    runs-on: ubuntu-latest
+    outputs:
+      should_run_e2e: ${{ steps.filter.outputs.should_run_e2e }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Decide whether E2E is required
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-only "$BASE_SHA" "$HEAD_SHA" > changed-files.txt
+
+          echo "Changed files:"
+          cat changed-files.txt
+
+          should_run_e2e=false
+
+          while IFS= read -r file; do
+            case "$file" in
+              docs/*|*.md)
+                ;;
+              *)
+                should_run_e2e=true
+                break
+                ;;
+            esac
+          done < changed-files.txt
+
+          echo "should_run_e2e=$should_run_e2e" >> "$GITHUB_OUTPUT"
+
+  e2e:
+    name: Run full E2E suite
+    needs: changes
+    if: needs.changes.outputs.should_run_e2e == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run full E2E suite
+        run: pnpm test:e2e
+
+      - name: Upload Playwright artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-artifacts
+          path: |
+            playwright-report
+            test-results
+          if-no-files-found: ignore
+
+  required:
+    name: Required PR E2E status
+    needs:
+      - changes
+      - e2e
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Enforce PR merge gate
+        env:
+          SHOULD_RUN_E2E: ${{ needs.changes.outputs.should_run_e2e }}
+          E2E_RESULT: ${{ needs.e2e.result }}
+        run: |
+          if [ "$SHOULD_RUN_E2E" = "true" ] && [ "$E2E_RESULT" != "success" ]; then
+            echo "::error::This PR changed code, so the full E2E suite must pass before merge."
+            exit 1
+          fi
+
+          if [ "$SHOULD_RUN_E2E" = "true" ]; then
+            echo "Full E2E suite passed."
+          else
+            echo "Docs-only PR detected. E2E was skipped."
+          fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -48,8 +48,8 @@ jobs:
       - name: Read package metadata
         id: pkg
         run: |
-          echo "name=$(node -p "require('./package.json').name")" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "name=$(node -p \"require('./package.json').name\")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
 
       - name: Check whether current version is already on npm
         id: npm
@@ -63,24 +63,24 @@ jobs:
       - name: Prepare release version
         id: release
         run: |
-          if [ "${{ steps.npm.outputs.published }}" = "true" ]; then
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-            echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
           head_subject="$(git log -1 --pretty=%s)"
-          if [[ "$head_subject" == chore\(release\):* ]]; then
+
+          if [ "${{ steps.npm.outputs.published }}" = "true" ] && [[ "$head_subject" == chore\(release\):* ]]; then
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          npm version patch --no-git-tag-version
-          pnpm install --lockfile-only
-          echo "needs_commit=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.npm.outputs.published }}" = "true" ]; then
+            npm version patch --no-git-tag-version
+            pnpm install --lockfile-only
+            echo "needs_commit=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "needs_commit=false" >> "$GITHUB_OUTPUT"
+          fi
+
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
+          echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
 
       - name: Build package
         if: steps.release.outputs.should_publish == 'true'
@@ -88,6 +88,8 @@ jobs:
 
       - name: Commit release version
         if: steps.release.outputs.needs_commit == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -95,13 +97,17 @@ jobs:
           git checkout -b "$branch"
           git add package.json pnpm-lock.yaml
           git commit -m "chore(release): v${{ steps.release.outputs.version }}"
-          git push origin "HEAD:$branch"
+          git push origin "HEAD:$branch" --force
+          # Close any existing PR for this branch
+          existing_pr=$(gh pr list --head "$branch" --state open --json number --jq '.[0].number')
+          if [ -n "$existing_pr" ]; then
+            gh pr close "$existing_pr"
+          fi
           gh pr create \
             --base main \
             --head "$branch" \
             --title "chore(release): v${{ steps.release.outputs.version }}" \
-            --body "Automated version bump to v${{ steps.release.outputs.version }}." \
-            --merge-commit-message "chore(release): v${{ steps.release.outputs.version }}"
+            --body "Automated version bump to v${{ steps.release.outputs.version }}."
 
       - name: Publish package
         if: steps.release.outputs.should_publish == 'true'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,35 +16,12 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    env:
-      RELEASE_APP_CLIENT_ID: ${{ secrets.RELEASE_APP_CLIENT_ID || vars.RELEASE_APP_CLIENT_ID }}
-      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
     steps:
-      - name: Validate release app credentials
-        run: |
-          if [ -z "${RELEASE_APP_CLIENT_ID}" ]; then
-            echo "::error::Missing RELEASE_APP_CLIENT_ID. Add it as an Actions secret or repository variable."
-            exit 1
-          fi
-
-          if [ -z "${RELEASE_APP_PRIVATE_KEY}" ]; then
-            echo "::error::Missing RELEASE_APP_PRIVATE_KEY. Add the GitHub App private key as an Actions secret."
-            exit 1
-          fi
-
-      - name: Generate GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v3
-        with:
-          client-id: ${{ env.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ env.RELEASE_APP_PRIVATE_KEY }}
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Sync to latest main
         run: |
@@ -86,22 +63,22 @@ jobs:
       - name: Prepare release version
         id: release
         run: |
-          head_subject="$(git log -1 --pretty=%s)"
-
-          if [ "${{ steps.npm.outputs.published }}" = "true" ] && [[ "$head_subject" == chore\(release\):* ]]; then
+          if [ "${{ steps.npm.outputs.published }}" = "true" ]; then
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [ "${{ steps.npm.outputs.published }}" = "true" ]; then
-            npm version patch --no-git-tag-version
-            pnpm install --lockfile-only
-            echo "needs_commit=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "needs_commit=false" >> "$GITHUB_OUTPUT"
+          head_subject="$(git log -1 --pretty=%s)"
+          if [[ "$head_subject" == chore\(release\):* ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          npm version patch --no-git-tag-version
+          pnpm install --lockfile-only
+          echo "needs_commit=true" >> "$GITHUB_OUTPUT"
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
@@ -114,10 +91,17 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          branch="release/v${{ steps.release.outputs.version }}"
+          git checkout -b "$branch"
           git add package.json pnpm-lock.yaml
           git commit -m "chore(release): v${{ steps.release.outputs.version }}"
-          git remote set-url origin "https://x-access-token:${{ steps.app-token.outputs.token }}@github.com/${{ github.repository }}.git"
-          git push origin HEAD:main
+          git push origin "HEAD:$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(release): v${{ steps.release.outputs.version }}" \
+            --body "Automated version bump to v${{ steps.release.outputs.version }}." \
+            --merge-commit-message "chore(release): v${{ steps.release.outputs.version }}"
 
       - name: Publish package
         if: steps.release.outputs.should_publish == 'true'

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -16,14 +16,29 @@ concurrency:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    env:
+      RELEASE_APP_CLIENT_ID: ${{ secrets.RELEASE_APP_CLIENT_ID || vars.RELEASE_APP_CLIENT_ID }}
+      RELEASE_APP_PRIVATE_KEY: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
     steps:
+      - name: Validate release app credentials
+        run: |
+          if [ -z "${RELEASE_APP_CLIENT_ID}" ]; then
+            echo "::error::Missing RELEASE_APP_CLIENT_ID. Add it as an Actions secret or repository variable."
+            exit 1
+          fi
+
+          if [ -z "${RELEASE_APP_PRIVATE_KEY}" ]; then
+            echo "::error::Missing RELEASE_APP_PRIVATE_KEY. Add the GitHub App private key as an Actions secret."
+            exit 1
+          fi
+
       - name: Generate GitHub App token
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          client-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
-          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          client-id: ${{ env.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ env.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- 新增 `pull_request` 触发的 GitHub Actions E2E 门禁流程。
- 对文档-only 变更自动跳过全量 E2E；对代码变更运行 `pnpm test:e2e`。
- 增加一个稳定的最终检查项，便于在分支保护里配置为必需状态检查，从而限制 PR 仅在 E2E 通过后合并。

## Testing
- Not run (not requested)