### PR TITLE
fix(ci): use PR for version bump instead of direct push

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -63,22 +63,22 @@ jobs:
       - name: Prepare release version
         id: release
         run: |
-          head_subject="$(git log -1 --pretty=%s)"
-
-          if [ "${{ steps.npm.outputs.published }}" = "true" ] && [[ "$head_subject" == chore\(release\):* ]]; then
+          if [ "${{ steps.npm.outputs.published }}" = "true" ]; then
             echo "should_publish=false" >> "$GITHUB_OUTPUT"
             echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
-          if [ "${{ steps.npm.outputs.published }}" = "true" ]; then
-            npm version patch --no-git-tag-version
-            pnpm install --lockfile-only
-            echo "needs_commit=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "needs_commit=false" >> "$GITHUB_OUTPUT"
+          head_subject="$(git log -1 --pretty=%s)"
+          if [[ "$head_subject" == chore\(release\):* ]]; then
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+            echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
+            exit 0
           fi
 
+          npm version patch --no-git-tag-version
+          pnpm install --lockfile-only
+          echo "needs_commit=true" >> "$GITHUB_OUTPUT"
           echo "should_publish=true" >> "$GITHUB_OUTPUT"
           echo "version=$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
 
@@ -91,9 +91,17 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          branch="release/v${{ steps.release.outputs.version }}"
+          git checkout -b "$branch"
           git add package.json pnpm-lock.yaml
           git commit -m "chore(release): v${{ steps.release.outputs.version }}"
-          git push origin HEAD:main
+          git push origin "HEAD:$branch"
+          gh pr create \
+            --base main \
+            --head "$branch" \
+            --title "chore(release): v${{ steps.release.outputs.version }}" \
+            --body "Automated version bump to v${{ steps.release.outputs.version }}." \
+            --merge-commit-message "chore(release): v${{ steps.release.outputs.version }}"
 
       - name: Publish package
         if: steps.release.outputs.should_publish == 'true'


### PR DESCRIPTION
Branch protection blocks direct pushes to main. This changes the CI to create a PR for the version bump commit instead.