### PR TITLE
fix(ci): remove invalid --merge-commit-message flag

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -100,8 +100,7 @@ jobs:
             --base main \
             --head "$branch" \
             --title "chore(release): v${{ steps.release.outputs.version }}" \
-            --body "Automated version bump to v${{ steps.release.outputs.version }}." \
-            --merge-commit-message "chore(release): v${{ steps.release.outputs.version }}"
+            --body "Automated version bump to v${{ steps.release.outputs.version }}."
 
       - name: Publish package
         if: steps.release.outputs.should_publish == 'true'


### PR DESCRIPTION
Remove the invalid --merge-commit-message flag from gh pr create. The squash merge will use the PR title as commit message.