### PR TITLE
docs: make auto-open mandatory in skill workflow (closes #25)

### DIFF
--- a/skills/starry-slides/SKILL.md
+++ b/skills/starry-slides/SKILL.md
@@ -28,7 +28,8 @@ For installation steps, supported commands, command purposes, and output example
 1. Make sure the `starry-slides` CLI is installed.
 2. Understand the user's slide context before generating anything. Use [REQUIREMENTS-DISCOVERY-INTERVIEW.md](references/REQUIREMENTS-DISCOVERY-INTERVIEW.md) to gather missing context, ask only the highest-signal questions, and consolidate the result into a brief before you generate.
 3. Generate or edit the deck package so it satisfies [STARRY-SLIDES-CONTRACT.md](references/STARRY-SLIDES-CONTRACT.md).
-4. Open the deck with:
+4. Verify the deck with `starry-slides verify <deck>`. If it fails, fix the issues and retry until it passes.
+5. **MUST DO:** After verification passes, run `starry-slides open <deck>`. This is **not optional** — the user expects to see their deck opened automatically.
 
 ```bash
 starry-slides open <deck>
@@ -36,6 +37,6 @@ starry-slides open <deck>
 
 ## Hints
 
+- ALWAYS run `starry-slides open <deck>` after a successful verify. Do not just tell the user the file is ready — open it for them.
 - After generation, you can use `starry-slides verify <deck>` to check whether the deck satisfies the contract.
 - To preview generated slides, use `starry-slides view <deck> --all` or `starry-slides view <deck> --slide <manifest-file>`.
-


### PR DESCRIPTION
Hey! 👋

This PR updates the starry-slides SKILL.md to make the auto-open step mandatory after deck generation and verification.

## What changed

The old workflow had "Open the deck" as step 4, but it was too easy to skip since there was no verification step first and the open wasn't explicitly marked as mandatory.

Here's what I did:

- Added a verification step (step 4) — agents now **must** run `starry-slides verify <deck>` and fix any issues before opening
- Made the open step (step 5) explicitly mandatory with a bold **MUST DO** label so it's clear this isn't optional
- Added a hint: "ALWAYS run `starry-slides open <deck>` after a successful verify. Do not just tell the user the file is ready — open it for them."

The idea is simple: if someone asks for a deck, they should see it open automatically — no extra prompting needed.

Closes #25