### PR TITLE
feat: add --port option to open command with auto-fallback (closes #27)

### DIFF
--- a/skills/starry-slides/references/STARRY-SLIDES-CLI-USAGE.md
+++ b/skills/starry-slides/references/STARRY-SLIDES-CLI-USAGE.md
@@ -30,8 +30,8 @@ The CLI currently supports these command forms:
 - `starry-slides verify [deck]`
 - `starry-slides view [deck] --all`
 - `starry-slides view [deck] --slide <manifest-file>`
-- `starry-slides open [deck]`
-- `starry-slides [deck]`
+- `starry-slides open [deck] [--port <number>]`
+- `starry-slides [deck] [--port <number>]`
 
 The last form is shorthand for `starry-slides open [deck]`.
 
@@ -189,10 +189,31 @@ What it does:
 - opens the editor in a browser
 - writes startup messages to stderr
 
+### `--port` option
+
+By default the editor starts on port 5173. Use `--port` to specify a different
+port:
+
+```bash
+starry-slides open <deck> --port 5180
+```
+
+If the requested port is already in use, the CLI automatically tries the next
+available port (up to 100 attempts). This lets you run multiple editors
+side-by-side without port conflicts:
+
+```bash
+# Terminal 1
+starry-slides open my-deck --port 5180
+
+# Terminal 2 — auto-falls-back to 5181 if 5180 is taken
+starry-slides open another-deck --port 5180
+```
+
 Example successful startup messages:
 
 ```text
-Opening Starry Slides at http://127.0.0.1:5173/
+Opening Starry Slides at http://127.0.0.1:5180/
 Press Ctrl+C to stop the editor server.
 ```
 
@@ -225,4 +246,10 @@ This behaves the same as:
 
 ```bash
 starry-slides open <deck>
+```
+
+The `--port` option works in this shorthand form as well:
+
+```bash
+starry-slides <deck> --port 5180
 ```

--- a/src/cli/commands/open/action.ts
+++ b/src/cli/commands/open/action.ts
@@ -8,7 +8,7 @@ function writeJson(value: unknown) {
   process.stdout.write(`${JSON.stringify(value, null, 2)}\n`);
 }
 
-export async function runOpen(deckPathArg: string | undefined) {
+export async function runOpen(deckPathArg: string | undefined, preferredPort?: number) {
   const deckPath = resolveDeckPath(deckPathArg);
   const result = await runFullVerify(deckPath);
   if (!result.ok) {
@@ -17,7 +17,7 @@ export async function runOpen(deckPathArg: string | undefined) {
     return;
   }
 
-  const port = await findAvailablePort(Number(process.env.PORT ?? 5173));
+  const port = await findAvailablePort(preferredPort ?? Number(process.env.PORT ?? 5173));
   const url = `http://127.0.0.1:${port}/`;
   if (process.env.STARRY_SLIDES_TEST_STUB_OPEN === "1") {
     console.error(`Opening Starry Slides at ${url}`);

--- a/src/cli/commands/open/index.ts
+++ b/src/cli/commands/open/index.ts
@@ -5,14 +5,18 @@ export function registerOpenCommand(program: Command) {
   program
     .command("open")
     .argument("[deck]", "deck path")
+    .option("--port <number>", "preferred port for the editor server", Number)
     .description("Open the editor after complete verification.")
-    .action(async (deckPath: string | undefined) => {
-      await runOpen(deckPath);
+    .action(async (deckPath: string | undefined, options: { port?: number }) => {
+      await runOpen(deckPath, options.port);
     });
 }
 
 export function registerDefaultOpen(program: Command) {
-  program.argument("[deck]", "deck path").action(async (deckPath: string | undefined) => {
-    await runOpen(deckPath);
-  });
+  program
+    .argument("[deck]", "deck path")
+    .option("--port <number>", "preferred port for the editor server", Number)
+    .action(async (deckPath: string | undefined, options: { port?: number }) => {
+      await runOpen(deckPath, options.port);
+    });
 }

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -1,5 +1,6 @@
 import { spawnSync } from "node:child_process";
 import fs from "node:fs";
+import net from "node:net";
 import path from "node:path";
 import { afterEach, describe, expect, test } from "vitest";
 import {
@@ -41,6 +42,13 @@ function runPackageScript(args: string[]) {
 
 function parseJson(stdout: string) {
   return JSON.parse(stdout) as Record<string, unknown>;
+}
+
+function holdPort(port: number): Promise<net.Server> {
+  return new Promise((resolve) => {
+    const server = net.createServer();
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
 }
 
 afterEach(() => {
@@ -320,9 +328,47 @@ describe("source starry-slides cli", () => {
       expect(result.status).toBe(0);
       expect(result.stderr).toBe("");
       expect(result.stdout).toContain("Usage: starry-slides [options] [command] [deck]");
-      expect(result.stdout).toContain("open [deck]");
+      expect(result.stdout).toContain("open [options] [deck]");
       expect(result.stdout).toContain("verify [deck]");
       expect(result.stdout).toContain("view [options] [deck]");
     }
+  });
+
+  test("open --port uses the specified port when available", () => {
+    const deck = writeValidDeck();
+
+    const result = runCli(["open", deck, "--port", "5280"], {
+      env: { STARRY_SLIDES_TEST_STUB_OPEN: "1" },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("http://127.0.0.1:5280/");
+  });
+
+  test("open --port auto-falls-back when the requested port is occupied", async () => {
+    const deck = writeValidDeck();
+    const blocker = await holdPort(5290);
+
+    try {
+      const result = runCli(["open", deck, "--port", "5290"], {
+        env: { STARRY_SLIDES_TEST_STUB_OPEN: "1" },
+      });
+
+      expect(result.status).toBe(0);
+      expect(result.stderr).toContain("Opening Starry Slides at http://127.0.0.1:5291/");
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()));
+    }
+  });
+
+  test("open defaults to port 5173 when no --port is specified", () => {
+    const deck = writeValidDeck();
+
+    const result = runCli(["open", deck], {
+      env: { STARRY_SLIDES_TEST_STUB_OPEN: "1", PORT: "5173" },
+    });
+
+    expect(result.status).toBe(0);
+    expect(result.stderr).toContain("http://127.0.0.1:5173/");
   });
 });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -14,6 +14,7 @@ function createProgram() {
     .helpCommand("help [command]")
     .showHelpAfterError()
     .allowExcessArguments(false)
+    .enablePositionalOptions()
     .configureOutput({
       writeOut: (str) => process.stdout.write(str),
       writeErr: (str) => process.stderr.write(str),


### PR DESCRIPTION
## Summary

This PR adds explicit port selection and automatic port-fallback to the `starry-slides open` command, addressing issue #27.

### Changes

**`src/cli/commands/open/action.ts`**
- Added `preferredPort` parameter to `runOpen()` — passed through to `findAvailablePort()`

**`src/cli/commands/open/index.ts`**
- Added `--port <number>` option to both `open` subcommand and default deck command
- Updated action callbacks to forward `options.port` to `runOpen()`

**`src/cli/index.ts`**
- Added `.enablePositionalOptions()` to the root program — required in Commander.js v14 so that `--port` on a subcommand is correctly routed instead of being consumed by the root program's option parser

**`src/cli/index.test.ts`**
- `open --port uses the specified port when available` — verifies explicit port selection
- `open --port auto-falls-back when the requested port is occupied` — verifies port-conflict recovery
- `open defaults to port 5173 when no --port is specified` — verifies default behavior
- Updated help text assertion: `open` now shows `[options] [deck]` due to the new `--port` flag

### Behavior

- `starry-slides open --port 5180` opens the editor on port 5180 when available
- If the requested port is occupied, `findAvailablePort()` tries the next 100 ports automatically
- Running two instances with different ports (or auto-fallback) enables multiple editors side-by-side

### Issue
Closes #27

---
*🤖 Auto-generated by Hermes Agent (issue-to-pr-workflow)*