### PR TITLE
docs: add package extraction ADR and product integration reference

### DIFF
--- a/docs/adr/0008-adopt-starrykit-slides-single-package.md
+++ b/docs/adr/0008-adopt-starrykit-slides-single-package.md
@@ -1,7 +1,8 @@
 # ADR-0008: Adopt @starrykit/slides as the single product package
 
-- Status: accepted
+- Status: superseded
 - Date: 2026-05-05
+- Superseded by: [ADR-0029](./0029-adopt-a-compatibility-preserving-package-extraction-path.md)
 - Supersedes: [ADR-0005](./0005-adopt-two-subject-skill-and-editor-architecture.md)
 
 ## Context

--- a/docs/adr/0029-adopt-a-compatibility-preserving-package-extraction-path.md
+++ b/docs/adr/0029-adopt-a-compatibility-preserving-package-extraction-path.md
@@ -1,0 +1,146 @@
+# ADR-0029: Adopt a compatibility-preserving package extraction path
+
+- Status: proposed
+- Date: 2026-05-16
+- Supersedes: [ADR-0008](./0008-adopt-starrykit-slides-single-package.md)
+
+## Context
+
+Starry Slides currently ships as a single `starry-slides` package with the CLI,
+editor runtime, local preview/rendering pipeline, and Skill entrypoint all tied
+together. That shape is still the correct compatibility surface for existing
+Skill users, who must keep the same install and command flow.
+
+The next product phase needs the open-source repo to expose reusable, versioned
+components for the editor and slide-domain logic so a closed-source product repo
+can embed them without inheriting the local CLI/server runtime. At the same
+time, the open-source repo must keep local rendering available for its own
+users.
+
+The render boundary also needs to stay portable: local rendering in OSS, server
+rendering in the product backend, but the same render plan and contract rules in
+both places.
+
+## Decision
+
+Adopt a compatibility-preserving workspace split:
+
+1. Keep `starry-slides` as the public compatibility package and user-facing
+   runtime.
+2. Introduce `@starrykit/slides-core` for slide contract, document model,
+   validation, history, operation, and export-planning logic.
+3. Introduce `@starrykit/slides-editor` for the embeddable React editor.
+4. Keep local server, browser launch, and local rendering execution inside the
+   `starry-slides` package internals.
+5. Make render planning live in `slides-core`, while render execution remains an
+   adapter that can be local in OSS or remote in the product backend.
+6. Release the compatibility package and the reusable packages in lockstep
+   SemVer versions.
+
+## Consequences
+
+Benefits:
+
+- current Skill users keep the same package name and command names
+- the product repo can consume stable reusable packages
+- local rendering remains available in the open-source repo
+- server-side rendering can later reuse the same planning logic
+- the editor becomes easier to embed because it consumes explicit props and
+  callbacks instead of product-specific globals
+
+Costs:
+
+- the repository becomes a workspace and needs stricter packaging discipline
+- the team must maintain explicit public APIs instead of deep-importing
+  internals
+- migration introduces compatibility wrappers and release coordination work
+
+Deferred:
+
+- whether the product backend later introduces a dedicated remote renderer
+  package
+- whether the root package later exports a minimal JS API in addition to the
+  CLI
+- whether the reusable packages later split into independently versioned
+  release tracks
+
+## Alternatives considered
+
+### Keep the single package forever
+
+Rejected. It preserves short-term simplicity but prevents the product repo from
+depending on reusable packages without also depending on the local runtime.
+
+### Extract the runtime into its own public package
+
+Rejected for now. The product repo does not need the local browser/server
+runtime as a separately published dependency.
+
+### Extract only the editor package
+
+Rejected. The product repo also needs the slide-domain logic and export-planning
+rules, not just the React UI.
+
+## Implementation Plan
+
+- **Affected paths**:
+  - `package.json`
+  - `pnpm-workspace.yaml`
+  - `packages/slides-core/package.json`
+  - `packages/slides-core/src/index.ts`
+  - `packages/slides-editor/package.json`
+  - `packages/slides-editor/src/index.tsx`
+  - `src/core/`
+  - `src/editor/`
+  - `src/node/`
+  - `src/cli/`
+  - `docs/adr/README.md`
+  - `README.md`
+  - `README.zh-CN.md`
+  - `skills/starry-slides/SKILL.md`
+  - `docs/skills-references/`
+
+- **Pattern**:
+  - keep `starry-slides` as the compatibility package that current Skill users
+    install
+  - expose only stable public APIs from `slides-core` and `slides-editor`
+  - keep Chromium/Playwright rendering and file-system runtime behavior in the
+    root package internals
+  - keep `slides-core` browser-safe and free of React and runtime dependencies
+  - keep `slides-editor` host-driven: inputs in, callbacks out
+  - use lockstep SemVer releases so the compatibility package and reusable
+    packages stay aligned
+
+- **Migration steps**:
+  - add workspace package manifests without changing the current CLI surface
+  - create compatibility re-export entry points for the new packages
+  - move or re-export the reusable core/editor APIs behind those package
+    boundaries
+  - add packaging checks that prove `starry-slides` still behaves the same for
+    Skill users
+  - update the product-facing docs to consume the new packages instead of
+    internal runtime modules
+
+- **Tests**:
+  - verify the root package still installs and runs the current CLI commands
+  - verify the Skill shell still references the same user-facing command names
+    and installation path
+  - verify the reusable packages can be imported without pulling in the local
+    runtime
+  - verify local preview and export flows still work in the open-source repo
+  - verify package builds and publish artifacts remain deterministic
+
+## Verification
+
+- [ ] `starry-slides verify`, `starry-slides view`, and `starry-slides open`
+      continue to work for existing Skill users without a command rename
+- [ ] the root `starry-slides` package still packages the CLI and Skill files
+      needed by current users
+- [ ] `@starrykit/slides-core` can be imported without React or local runtime
+      dependencies
+- [ ] `@starrykit/slides-editor` can be embedded by a product host through
+      props and callbacks rather than product-specific global state
+- [ ] local rendering for preview and export still works in the open-source
+      repository
+- [ ] workspace builds and tests pass in a lockstep release workflow
+

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -37,7 +37,7 @@ Update this directory whenever a change affects:
 | [0005](./0005-adopt-two-subject-skill-and-editor-architecture.md)               | Adopt two-subject architecture for Starry Slides Skill and Editor               | superseded            |
 | [0006](./0006-unify-element-tooling-into-shared-toolbar-model.md)               | Unify element tooling into a shared toolbar model                               | superseded            |
 | [0007](./0007-limit-generated-deck-copies.md)                                   | Limit generated deck copies                                                     | superseded            |
-| [0008](./0008-adopt-starrykit-slides-single-package.md)                         | Adopt @starrykit/slides as the single product package                           | accepted              |
+| [0008](./0008-adopt-starrykit-slides-single-package.md)                         | Adopt @starrykit/slides as the single product package                           | superseded            |
 | [0009](./0009-use-floating-toolbar-as-the-only-element-tooling-surface.md)      | Use Floating Toolbar as the only element tooling surface                        | accepted              |
 | [0010](./0010-represent-groups-as-nested-dom-containers.md)                     | Represent groups as nested DOM containers                                       | accepted              |
 | [0011](./0011-adopt-starry-slides-agent-facing-cli.md)                          | Adopt starry-slides as the agent-facing CLI                                     | accepted              |
@@ -57,3 +57,4 @@ Update this directory whenever a change affects:
 | [0026](./0026-adopt-single-generated-regression-deck-path.md)                   | Adopt single generated regression deck path                                     | accepted              |
 | [0027](./0027-adopt-v1-deck-contract-and-track-cli-editor-refactors.md)         | Adopt V1 deck contract and track CLI and editor refactors                       | accepted              |
 | [0028](./0028-adopt-notify-only-runtime-updates-and-remote-skill-references.md) | Adopt notify-only runtime updates and remote Skill references                   | proposed              |
+| [0029](./0029-adopt-a-compatibility-preserving-package-extraction-path.md)      | Adopt a compatibility-preserving package extraction path                        | proposed              |

--- a/docs/product/integration-reference.md
+++ b/docs/product/integration-reference.md
@@ -1,0 +1,133 @@
+# Product Integration Reference
+
+This document explains how a product repository should use the Starry Slides
+open-source packages.
+
+## Purpose
+
+- reuse the slide-domain logic and editor UI from the open-source repo
+- keep product concerns such as auth, billing, workspace storage, and remote
+  rendering outside the shared OSS packages
+- preserve the ability to swap local rendering for server-side rendering later
+
+## Public Components
+
+Use these OSS packages as the only supported integration surface:
+
+```ts
+import { ... } from "@starrykit/slides-core";
+import { SlidesEditor } from "@starrykit/slides-editor";
+```
+
+- `@starrykit/slides-core`
+  - slide contract parsing and validation
+  - document/history/operation logic
+  - export planning and selection rules
+  - render planning data
+
+- `@starrykit/slides-editor`
+  - the React editor UI
+  - slide canvas, selection, toolbar, sidebar, and history UI
+  - host-driven callbacks for save, export, agent actions, and deck switching
+
+- `starry-slides`
+  - keep this only as the open-source CLI/runtime package for local use
+  - do not make the product app depend on its local CLI/server implementation
+
+## Product Module Mapping
+
+### Workspace
+
+Use product-owned persistence for deck lists, folders, metadata, sharing state,
+and version history.
+
+Use `slides-core` only for reading and writing slide HTML and for applying
+editor operations to deck data.
+
+### Editor Page
+
+Embed `SlidesEditor` inside the product editor route.
+
+The host should provide:
+
+- current slides
+- deck title
+- save callbacks
+- export callbacks
+- agent action callbacks
+- loading and saving state
+
+The editor should not own auth, billing, workspace navigation, or database
+access.
+
+### Agent Workflow
+
+Use `slides-core` for:
+
+- validating generated or modified slide HTML
+- resolving selection scopes
+- applying structured edit operations when possible
+- planning exports or previews before execution
+
+Use the product backend for:
+
+- calling the model provider
+- storing prompts, proposals, and audit records
+- approving or rejecting changes
+- persisting accepted results
+
+### Preview and Export
+
+Keep the planning contract in `slides-core`, but execute rendering in the
+product backend.
+
+Recommended flow:
+
+1. product UI requests a preview or export
+2. backend uses `slides-core` to resolve the requested slides and render plan
+3. backend renders with its own worker or executor
+4. backend stores the result and returns an API response to the UI
+
+This lets the product replace the open-source local renderer with a server-side
+executor without changing editor state management or export semantics.
+
+### Upload and Asset Handling
+
+Use product-owned storage for uploaded images, source files, generated assets,
+and deck snapshots.
+
+Use `slides-core` only to normalize paths, validate contract rules, and preserve
+the HTML-first deck model.
+
+## Recommended Integration Pattern
+
+```ts
+import { validateDeck, planPdfExport } from "@starrykit/slides-core";
+import { SlidesEditor } from "@starrykit/slides-editor";
+
+const result = validateDeck(deckHtml);
+const plan = planPdfExport({ slides, selection });
+```
+
+- keep all product-specific I/O outside the OSS packages
+- pass data into the editor as props, not as hidden globals
+- keep remote rendering and local rendering interchangeable behind a product
+  service boundary
+
+## What Not to Depend On
+
+- local CLI process spawning
+- browser launcher internals
+- file-system deck mounts
+- Playwright or Chromium runtime details
+- root-package private modules under `src/`
+- product auth or billing logic inside OSS packages
+
+## Upgrade Model
+
+- pin OSS packages by SemVer
+- update `slides-core` and `slides-editor` together when an API change affects
+  both
+- treat `starry-slides` as a compatibility and runtime package, not as the
+  product app's architecture foundation
+


### PR DESCRIPTION
This PR adds:\n- ADR-0029 for the compatibility-preserving package extraction path\n- a product integration reference for consuming the OSS editor/core packages\n- ADR index updates and supersession of ADR-0008\n\nNo implementation changes are included.