### PR TITLE
Remove tracked worktree artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ docs/agents/
 .tmp
 
 sample-slides/
+worktrees/


### PR DESCRIPTION
## Summary
- remove the accidentally tracked `worktrees/pr-59` gitlink from the repository
- ignore root-level `worktrees/` so local scratch worktrees do not get committed again

## Verification
- checked `git status` and the diff before committing