### PR TITLE
Fix publish workflow for partial-published npm state

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -102,19 +102,62 @@ jobs:
       - name: Decide release action
         id: release
         run: |
-          if [ "${{ steps.npm.outputs.published }}" != "true" ] || [ "${{ steps.npm.outputs.core_published }}" != "true" ] || [ "${{ steps.npm.outputs.editor_published }}" != "true" ]; then
+          if [ "${{ steps.npm.outputs.published }}" != "true" ] && [ "${{ steps.npm.outputs.core_published }}" != "true" ] && [ "${{ steps.npm.outputs.editor_published }}" != "true" ]; then
             echo "mode=publish" >> "$GITHUB_OUTPUT"
             echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
           if [[ "${{ steps.pkg.outputs.head_subject }}" == chore\(release\):* ]]; then
-            echo "mode=skip" >> "$GITHUB_OUTPUT"
-            echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
-            exit 0
+            if [ "${{ steps.npm.outputs.published }}" = "true" ] && [ "${{ steps.npm.outputs.core_published }}" = "true" ] && [ "${{ steps.npm.outputs.editor_published }}" = "true" ]; then
+              echo "mode=skip" >> "$GITHUB_OUTPUT"
+              echo "version=${{ steps.pkg.outputs.version }}" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
 
-          base_version="${{ steps.npm.outputs.latest_version }}"
+          latest_versions=()
+
+          if [ -n "${{ steps.npm.outputs.latest_version }}" ]; then
+            latest_versions+=("${{ steps.npm.outputs.latest_version }}")
+          fi
+
+          if npm view "@starrykit/slides-core" dist-tags.latest >/dev/null 2>&1; then
+            latest_versions+=("$(npm view "@starrykit/slides-core" dist-tags.latest 2>/dev/null || true)")
+          fi
+
+          if npm view "@starrykit/slides-editor" dist-tags.latest >/dev/null 2>&1; then
+            latest_versions+=("$(npm view "@starrykit/slides-editor" dist-tags.latest 2>/dev/null || true)")
+          fi
+
+          base_version="${latest_versions[0]}"
+
+          for version in "${latest_versions[@]}"; do
+            if [ -z "$version" ]; then
+              continue
+            fi
+
+            if [ -z "$base_version" ]; then
+              base_version="$version"
+              continue
+            fi
+
+            if node -e '
+              const [a, b] = process.argv.slice(1);
+              const parse = (value) => value.split(".").map(Number);
+              const [am, an, ap] = parse(a);
+              const [bm, bn, bp] = parse(b);
+              if ([am, an, ap, bm, bn, bp].some((part) => Number.isNaN(part))) {
+                throw new Error(`Invalid semver comparison: ${a} vs ${b}`);
+              }
+              const left = [am, an, ap];
+              const right = [bm, bn, bp];
+              const isGreater = left[0] > right[0] || (left[0] === right[0] && (left[1] > right[1] || (left[1] === right[1] && left[2] > right[2])));
+              process.exit(isGreater ? 0 : 1);
+            ' "$version" "$base_version"; then
+              base_version="$version"
+            fi
+          done
 
           if [ -z "$base_version" ]; then
             base_version="${{ steps.pkg.outputs.version }}"

--- a/package.json
+++ b/package.json
@@ -50,8 +50,8 @@
     "verify": "pnpm lint && pnpm test && pnpm build && pnpm test:packaged-cli && pnpm test:e2e"
   },
   "dependencies": {
-    "@starrykit/slides-core": "0.1.23",
-    "@starrykit/slides-editor": "0.1.23",
+    "@starrykit/slides-core": "0.1.25",
+    "@starrykit/slides-editor": "0.1.25",
     "@playwright/test": "^1.54.2",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/packages/slides-core/package.json
+++ b/packages/slides-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starrykit/slides-core",
-  "version": "0.1.23",
+  "version": "0.1.25",
   "description": "Slide contract, document model, validation, history, operations, and export-planning logic for Starry Slides.",
   "license": "MIT",
   "type": "module",

--- a/packages/slides-editor/package.json
+++ b/packages/slides-editor/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@starrykit/slides-editor",
-  "version": "0.1.23",
+  "version": "0.1.25",
   "description": "Embeddable React editor UI for Starry Slides — host-driven through props and callbacks.",
   "license": "MIT",
   "type": "module",
@@ -18,7 +18,7 @@
     "build": "tsc -p tsconfig.json && tsup src/index.tsx --format esm --external react --external react-dom"
   },
   "dependencies": {
-    "@starrykit/slides-core": "0.1.23",
+    "@starrykit/slides-core": "0.1.25",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "html-to-image": "^1.11.11",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,10 +12,10 @@ importers:
         specifier: ^1.54.2
         version: 1.59.1
       '@starrykit/slides-core':
-        specifier: 0.1.23
+        specifier: 0.1.25
         version: link:packages/slides-core
       '@starrykit/slides-editor':
-        specifier: 0.1.23
+        specifier: 0.1.25
         version: link:packages/slides-editor
       class-variance-authority:
         specifier: ^0.7.1
@@ -105,7 +105,7 @@ importers:
   packages/slides-editor:
     dependencies:
       '@starrykit/slides-core':
-        specifier: 0.1.23
+        specifier: 0.1.25
         version: link:../slides-core
       class-variance-authority:
         specifier: ^0.7.1


### PR DESCRIPTION
This fixes the Publish to npm workflow when only some packages for a release version are already on npm.

Changes:
- sync root/core/editor versions to 0.1.25
- align internal dependency pins and lockfile
- update workflow release decision logic so partial-published states create a release PR instead of attempting a republish

Verified locally with the same package-version validation snippet and workflow syntax checks.