### PR TITLE
docs: fix README logo path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./src/editor/assets/logo-starry-slides.png" alt="Starry Slides" width="420" />
+  <img src="./packages/slides-editor/src/assets/logo-starry-slides.png" alt="Starry Slides" width="420" />
 </p>
 
 <p align="center">

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,5 +1,5 @@
 <p align="center">
-  <img src="./src/editor/assets/logo-starry-slides.png" alt="Starry Slides" width="420" />
+  <img src="./packages/slides-editor/src/assets/logo-starry-slides.png" alt="Starry Slides" width="420" />
 </p>
 
 <p align="center">


### PR DESCRIPTION
## What this does

- Updates README logo paths after the package split moved editor assets under `packages/slides-editor`.
- Applies the same fix to the Chinese README.

## Verification

- Checked local README image refs resolve to existing files.

Fixes the broken README logo introduced by #78.

---
*Auto-generated by Hermes Agent*