### PR TITLE
fix: scale sidebar thumbnail captures

### DIFF
--- a/docs/e2e.md
+++ b/docs/e2e.md
@@ -70,6 +70,7 @@ Scope notes:
 | Slide context menu delete removes the slide card and keeps an adjacent slide active | Sidebar context menu | Regression deck | Slide count decrements after delete; an adjacent slide remains active | Undo/redo not asserted | Reload not asserted | `editor-chrome.spec.ts` |
 | Sidebar drag reorder changes slide order and survives reload | Sidebar drag | Regression deck | First slide dragged to third position; visible ordering changes; saving badge appears; reload preserves new order | Undo/redo not asserted | Reload asserted | `editor-chrome.spec.ts` |
 | Sidebar drag shows an insertion marker while reordering | Sidebar drag | Regression deck | Insertion marker appears between slide cards while dragging | N/A | N/A | `editor-chrome.spec.ts` |
+| Sidebar thumbnail rendering scales full-size slide content into the thumbnail canvas | Sidebar thumbnail image | Regression deck slide 19 | A bottom-right edge marker is visible on the stage and decoded from lower-right thumbnail pixels, proving the thumbnail was scaled instead of cropped to the upper-left | N/A | N/A | `editor-chrome.spec.ts` |
 | PDF export opens a scope dialog and submits selected-slides or all-slides payloads | Export menu, dialog | Regression deck | Export dialog defaults to All slides; Selected slides picker renders thumbnails; intercepted request payloads match chosen scope; success toast appears | N/A | Dialog reset on reopen asserted | `editor-chrome.spec.ts` |
 
 ## Text Content Editing And Native Text Selection

--- a/e2e/tests/deck-local-assets.spec.ts
+++ b/e2e/tests/deck-local-assets.spec.ts
@@ -4,8 +4,8 @@ import { coverFrame, gotoEditor } from "./helpers";
 test("editor loads deck-local image assets referenced from slide HTML", async ({ page }) => {
   await gotoEditor(page);
 
-  // Slide 17 contains the deck-local-image fixture. The last slide (18) is the
-  // positioned-ungroup fixture and does not contain deck-local image assets.
+  // Slide 17 contains the deck-local-image fixture; later slides do not
+  // contain deck-local image assets.
   const slideButton = page.getByLabel("Slide 17");
   await slideButton.click();
 

--- a/e2e/tests/editor-chrome.spec.ts
+++ b/e2e/tests/editor-chrome.spec.ts
@@ -190,6 +190,67 @@ test("sidebar renders fixed thumbnail list chrome and slide actions", async ({ p
   }
 });
 
+test("sidebar thumbnail scales full-size slide content instead of cropping edges", async ({
+  page,
+}) => {
+  await gotoEditor(page);
+
+  const slideButton = page.getByLabel(`Slide ${REGRESSION_DECK_SLIDE_COUNT}`);
+  await slideButton.click();
+  await expect(coverFrame(page).getByTestId("thumbnail-bottom-right-marker")).toBeVisible();
+
+  const thumbnailImage = slideButton.getByTestId("slide-thumbnail").locator("img");
+  await expect(thumbnailImage).toBeVisible({ timeout: 10_000 });
+  await expect.poll(async () => thumbnailImage.getAttribute("src")).toContain("data:image/png");
+
+  await expect
+    .poll(async () => {
+      return thumbnailImage.evaluate(async (node) => {
+        const image = node as HTMLImageElement;
+        if (!image.complete || image.naturalWidth === 0 || image.naturalHeight === 0) {
+          return 0;
+        }
+
+        try {
+          await image.decode();
+        } catch {
+          // A complete data URL image can already be drawable even if decode races.
+        }
+
+        const canvas = document.createElement("canvas");
+        canvas.width = image.naturalWidth;
+        canvas.height = image.naturalHeight;
+
+        const context = canvas.getContext("2d");
+        if (!context) {
+          return 0;
+        }
+
+        context.drawImage(image, 0, 0);
+
+        const sampleX = Math.floor(canvas.width * 0.86);
+        const sampleY = Math.floor(canvas.height * 0.82);
+        const sampleWidth = canvas.width - sampleX;
+        const sampleHeight = canvas.height - sampleY;
+        const pixels = context.getImageData(sampleX, sampleY, sampleWidth, sampleHeight).data;
+        let magentaPixels = 0;
+
+        for (let index = 0; index < pixels.length; index += 4) {
+          const red = pixels[index] ?? 0;
+          const green = pixels[index + 1] ?? 0;
+          const blue = pixels[index + 2] ?? 0;
+          const alpha = pixels[index + 3] ?? 0;
+          if (red > 220 && green < 80 && blue > 220 && alpha > 200) {
+            magentaPixels += 1;
+          }
+        }
+
+        return magentaPixels;
+      });
+    })
+    .toBeGreaterThan(20);
+});
+
 test("sidebar context menu adds slides above and below the clicked slide", async ({ page }) => {
   await gotoEditor(page);
 

--- a/e2e/tests/editor-chrome.spec.ts
+++ b/e2e/tests/editor-chrome.spec.ts
@@ -258,7 +258,7 @@ test("sidebar context menu adds slides above and below the clicked slide", async
   await page.getByRole("menu", { name: "Slide actions" }).getByText("Add Slide Above").click();
 
   await expect(page.getByText(`${REGRESSION_DECK_SLIDE_COUNT + 1} slides`)).toBeVisible();
-  await expect(page.getByLabel("Slide 2")).toHaveAttribute("aria-current", "true");
+  await expect(page.getByLabel("Slide 2", { exact: true })).toHaveAttribute("aria-current", "true");
   await expect(coverFrame(page).locator('[data-editable-id="text-1"]')).toHaveText(
     "Untitled Slide"
   );

--- a/e2e/tests/regression-deck.ts
+++ b/e2e/tests/regression-deck.ts
@@ -17,4 +17,4 @@ export const REGRESSION_DECK_SUMMARY = regressionDeckConfig.summary;
 export const REGRESSION_DECK_SOURCE_LABEL = `Generated deck: ${regressionDeckConfig.deckTitle}`;
 export const REGRESSION_DECK_HERO_KICKER = regressionDeckConfig.heroKicker;
 export const REGRESSION_DECK_AGENDA_PARAGRAPH = regressionDeckConfig.agendaParagraph;
-export const REGRESSION_DECK_SLIDE_COUNT = 18;
+export const REGRESSION_DECK_SLIDE_COUNT = 19;

--- a/e2e/tools/generate-regression-deck.mjs
+++ b/e2e/tools/generate-regression-deck.mjs
@@ -6,6 +6,7 @@ import {
   buildCropImageSlide,
   buildDeckLocalImageSlide,
   buildImageSlide,
+  buildThumbnailEdgeSlide,
 } from "./regression-deck/image-slide.mjs";
 import { buildAgendaSlide, buildHeroSlide } from "./regression-deck/intro-slides.mjs";
 import {
@@ -141,6 +142,11 @@ const slides = [
     file: "18-positioned-ungroup.html",
     title: "Positioned ungroup fixture",
     html: buildPositionedUngroupSlide(),
+  },
+  {
+    file: "19-thumbnail-edge.html",
+    title: "Thumbnail edge fixture",
+    html: buildThumbnailEdgeSlide(),
   },
 ];
 

--- a/e2e/tools/regression-deck/image-slide.mjs
+++ b/e2e/tools/regression-deck/image-slide.mjs
@@ -271,3 +271,24 @@ export function buildDeckLocalImageSlide() {
     `
   );
 }
+
+export function buildThumbnailEdgeSlide() {
+  return wrapHtml(
+    `${baseStyles("#ffffff")}
+    .slide-container {
+      padding: 0;
+      background: #ffffff;
+    }
+    .thumbnail-marker {
+      position: absolute;
+      right: 0;
+      bottom: 0;
+      width: 240px;
+      height: 160px;
+      background: #ff00ff;
+    }`,
+    `
+      <div class="thumbnail-marker" data-testid="thumbnail-bottom-right-marker"></div>
+    `
+  );
+}

--- a/packages/slides-core/src/generated-deck.test.ts
+++ b/packages/slides-core/src/generated-deck.test.ts
@@ -162,7 +162,7 @@ describe("generated deck import", () => {
     const secondSlide = parseSlide(secondSlideHtml, "generated-slide-2");
 
     expect(manifest.deckTitle).toBe(regressionDeckConfig.deckTitle);
-    expect(manifest.slides).toHaveLength(18);
+    expect(manifest.slides).toHaveLength(19);
     expect(firstSlide.id).toBe("generated-slide-1");
     expect(firstSlide.width).toBe(DEFAULT_SLIDE_WIDTH);
     expect(firstSlide.height).toBe(DEFAULT_SLIDE_HEIGHT);

--- a/packages/slides-editor/src/lib/thumbnail-renderer.test.ts
+++ b/packages/slides-editor/src/lib/thumbnail-renderer.test.ts
@@ -1,0 +1,117 @@
+import type { SlideModel } from "@starrykit/slides-core";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { renderSlideThumbnail } from "./thumbnail-renderer";
+
+const toPngMock = vi.hoisted(() => vi.fn());
+
+vi.mock("html-to-image", () => ({
+  toPng: toPngMock,
+}));
+
+function createSlide(overrides: Partial<SlideModel> = {}): SlideModel {
+  return {
+    id: "slide-1",
+    title: "Full-size slide",
+    width: 1920,
+    height: 1080,
+    rootSelector: "body",
+    sourceFile: "slides/slide-1.html",
+    elements: [],
+    htmlSource: `<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <style>
+      html,
+      body {
+        margin: 0;
+        width: 1920px;
+        height: 1080px;
+      }
+
+      body {
+        background: rgb(11, 18, 32);
+        position: relative;
+      }
+    </style>
+  </head>
+  <body>
+    <div data-testid="top-left" style="position: absolute; left: 0; top: 0;">TL</div>
+    <div data-testid="top-right" style="position: absolute; right: 0; top: 0;">TR</div>
+    <div data-testid="bottom-left" style="position: absolute; left: 0; bottom: 0;">BL</div>
+    <div data-testid="bottom-right" style="position: absolute; right: 0; bottom: 0;">BR</div>
+  </body>
+</html>`,
+    ...overrides,
+  };
+}
+
+describe("renderSlideThumbnail", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    toPngMock.mockReset();
+    toPngMock.mockResolvedValue("data:image/png;base64,thumbnail");
+  });
+
+  test("captures a scaled full-size slide on initial render instead of cropping the upper-left", async () => {
+    const slide = createSlide();
+
+    await renderSlideThumbnail(slide);
+
+    expect(toPngMock).toHaveBeenCalledTimes(1);
+    const [renderTarget, options] = toPngMock.mock.calls[0] as [
+      HTMLElement,
+      { canvasWidth: number; canvasHeight: number; pixelRatio: number },
+    ];
+    const scaledSlide = renderTarget.firstElementChild as HTMLElement | null;
+
+    expect(options).toMatchObject({
+      width: 224,
+      height: 126,
+      canvasWidth: 224,
+      canvasHeight: 126,
+      pixelRatio: 2,
+    });
+    expect(renderTarget.style.width).toBe("224px");
+    expect(renderTarget.style.height).toBe("126px");
+    expect(renderTarget.style.overflow).toBe("hidden");
+    expect(scaledSlide?.tagName).toBe("BODY");
+    expect(scaledSlide?.style.width).toBe("1920px");
+    expect(scaledSlide?.style.height).toBe("1080px");
+    expect(scaledSlide?.style.transform).toBe("scale(0.11666666666666667)");
+    expect(scaledSlide?.style.transformOrigin).toBe("top left");
+    expect(scaledSlide?.querySelector('[data-testid="bottom-right"]')?.textContent).toBe("BR");
+  });
+
+  test("uses the slide aspect ratio for non-default fixed slide sizes", async () => {
+    const slide = createSlide({
+      width: 1000,
+      height: 1000,
+      htmlSource: `<!DOCTYPE html>
+<html lang="en">
+  <body style="margin: 0; width: 1000px; height: 1000px;">
+    <div style="position: absolute; right: 0; bottom: 0;">BR</div>
+  </body>
+</html>`,
+    });
+
+    await renderSlideThumbnail(slide);
+
+    const [renderTarget, options] = toPngMock.mock.calls[0] as [
+      HTMLElement,
+      { canvasWidth: number; canvasHeight: number },
+    ];
+    const scaledSlide = renderTarget.firstElementChild as HTMLElement | null;
+
+    expect(options).toMatchObject({
+      width: 224,
+      height: 224,
+      canvasWidth: 224,
+      canvasHeight: 224,
+    });
+    expect(renderTarget.style.width).toBe("224px");
+    expect(renderTarget.style.height).toBe("224px");
+    expect(scaledSlide?.style.width).toBe("1000px");
+    expect(scaledSlide?.style.height).toBe("1000px");
+    expect(scaledSlide?.style.transform).toBe("scale(0.224)");
+  });
+});

--- a/packages/slides-editor/src/lib/thumbnail-renderer.ts
+++ b/packages/slides-editor/src/lib/thumbnail-renderer.ts
@@ -56,7 +56,7 @@ export async function renderSlideThumbnail(slide: SlideModel): Promise<string> {
       throw new Error("Slide root not found while rendering thumbnail.");
     }
 
-    const renderTarget = doc.body ?? root;
+    const renderTarget = createThumbnailRenderTarget(doc, doc.body ?? root, slide);
 
     return await renderThumbnailPng(doc, renderTarget, slide);
   } finally {
@@ -85,11 +85,14 @@ async function waitForImages(doc: Document) {
 }
 
 async function renderThumbnailPng(doc: Document, renderTarget: HTMLElement, slide: SlideModel) {
+  const thumbnailSize = getThumbnailSize(slide);
   const options = {
     cacheBust: true,
     pixelRatio: THUMBNAIL_PIXEL_RATIO,
-    canvasWidth: THUMBNAIL_DISPLAY_WIDTH,
-    canvasHeight: Math.round((slide.height / slide.width) * THUMBNAIL_DISPLAY_WIDTH),
+    width: thumbnailSize.width,
+    height: thumbnailSize.height,
+    canvasWidth: thumbnailSize.width,
+    canvasHeight: thumbnailSize.height,
     skipFonts: false,
   };
 
@@ -99,6 +102,55 @@ async function renderThumbnailPng(doc: Document, renderTarget: HTMLElement, slid
     removeBrokenImages(doc);
     return await toPng(renderTarget, options);
   }
+}
+
+function getThumbnailSize(slide: SlideModel) {
+  return {
+    width: THUMBNAIL_DISPLAY_WIDTH,
+    height: Math.round((slide.height / slide.width) * THUMBNAIL_DISPLAY_WIDTH),
+  };
+}
+
+function createThumbnailRenderTarget(doc: Document, root: HTMLElement, slide: SlideModel) {
+  const thumbnailSize = getThumbnailSize(slide);
+  const scale = Math.min(thumbnailSize.width / slide.width, thumbnailSize.height / slide.height);
+  const scaledRoot = cloneSlideRoot(root);
+  const frame = doc.createElement("div");
+  const rootStyle = doc.defaultView?.getComputedStyle(root);
+  const rootBackground = rootStyle?.background;
+
+  frame.style.width = `${thumbnailSize.width}px`;
+  frame.style.height = `${thumbnailSize.height}px`;
+  frame.style.position = "relative";
+  frame.style.overflow = "hidden";
+  frame.style.margin = "0";
+  frame.style.padding = "0";
+  frame.style.boxSizing = "border-box";
+
+  if (rootBackground && rootBackground !== "rgba(0, 0, 0, 0)" && rootBackground !== "transparent") {
+    frame.style.background = rootBackground;
+  }
+
+  scaledRoot.style.width = `${slide.width}px`;
+  scaledRoot.style.height = `${slide.height}px`;
+  scaledRoot.style.position = "absolute";
+  scaledRoot.style.left = "0";
+  scaledRoot.style.top = "0";
+  scaledRoot.style.margin = "0";
+  scaledRoot.style.maxWidth = "none";
+  scaledRoot.style.maxHeight = "none";
+  scaledRoot.style.boxSizing = "border-box";
+  scaledRoot.style.transform = `scale(${scale})`;
+  scaledRoot.style.transformOrigin = "top left";
+
+  frame.appendChild(scaledRoot);
+  doc.body.appendChild(frame);
+
+  return frame;
+}
+
+function cloneSlideRoot(root: HTMLElement) {
+  return root.cloneNode(true) as HTMLElement;
 }
 
 function removeBrokenImages(doc: Document) {


### PR DESCRIPTION
Closes #93.

## What changed
- Render sidebar thumbnails from an explicitly scaled clone/wrapper instead of asking html-to-image to capture the full-size slide into a small canvas.
- Keep the iframe at the authored slide size, then create a thumbnail-sized render target with the full slide scaled down from the top-left origin.
- Added regression coverage for the initial render path using a 1920x1080 slide with bottom-right content, plus a non-default fixed slide size.

## Verification
- pnpm test packages/slides-editor/src/lib/thumbnail-renderer.test.ts
- pnpm --filter @starrykit/slides-editor build

## Note
A broader root test run surfaced an existing/ambient CLI port expectation failure where the test expected port 5173 but the process opened 5174; this change does not touch the CLI port selection path.
