### PR TITLE
docs: add product version note to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@
 
 Starry Slides is a slide/presentation editor that gives your agent ability to generate fully editable slides with HTML as the source file.
 
+> We are building the product version now. The open-source version still receives bug fixes, and Editor updates will be synced back here periodically.
+
 ## Features
 
 <table>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,8 @@
 
 Starry Slides 是一个基于 AI Agent 的幻灯片/演示文稿编辑器，让你的 Agent 使用 HTML 作为源文件生成完全可编辑的 PPT。
 
+> 我们正在开发产品版；开源版会持续修复 Bug，Editor 更新也会周期性同步到这里。
+
 ## Features
 
 <table>


### PR DESCRIPTION
## Summary
- add a short product-version note under the README overview
- keep the Chinese README in sync

## Testing
- not run; documentation-only change