### PR TITLE
Simplify README features and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,8 @@
   <a href="#install">Install</a> ·
   <a href="#see-it-in-action">Demos</a> ·
   <a href="#usage">Usage</a> ·
-  <a href="#metrics">Metrics</a> ·
   <a href="#features">Features</a> ·
-  <a href="#manual-setup">Manual setup</a> ·
+  <a href="docs/README.md">Manual setup</a> ·
   <a href="https://starrykit.com">Website</a>
 </p>
 
@@ -35,7 +34,7 @@ Skill: npx skills add StarryKit/starrykit-plugin --skill starrykit-authoring -g 
 MCP: https://mcp.starrykit.com/mcp
 ```
 
-Your agent installs the Skill, configures the MCP, and opens browser OAuth. For manual installation, choose your host in [Manual setup](#manual-setup).
+Your agent installs the Skill, configures the MCP, and opens browser OAuth. If needed, open the [manual setup guides](docs/README.md).
 
 ## See it in action
 
@@ -62,36 +61,13 @@ Each request produces an editable StarryKit result you can review and continue r
 
 You can also ask StarryKit to inspect an existing document, tighten its story, redesign one page, reorder content, or export selected pages.
 
-## Metrics
-
-| ⚡ 1 prompt install | 🧰 14 MCP tools | 📤 7 export formats | 🔐 Browser OAuth |
-| --- | --- | --- | --- |
-| Skill + MCP setup | Read, author, preview, and export | PPTX, PDF, SVG, PNG, JPEG, HTML, Google Slides | No pasted access tokens |
-
 ## Features
 
-| Feature | What your agent can do |
+| Feature | What it means |
 | --- | --- |
-| ✨ Visual creation | Create presentations, posters, social graphics, invitations, and other editable designs. |
-| 🔎 Document discovery | Browse only the StarryKit documents and folders you authorize. |
-| 🎨 Design direction | Apply clear hierarchy, intentional composition, and page-specific art direction. |
-| 🛠 Focused editing | Read content and previews, then edit, rewrite, retitle, or reorder the right page. |
-| ✅ Reviewable drafts | Hand every generated page back to you for review inside StarryKit. |
-| 📤 Flexible export | Export a complete document or selected pages in seven supported formats. |
-
-## Manual setup
-
-If your agent cannot complete installation automatically, use the bilingual guide for your host:
-
-| Host | English | 中文 |
-| --- | --- | --- |
-| Codex | [Setup](docs/codex/README.md) | [安装](docs/codex/README.zh-CN.md) |
-| Claude Code | [Setup](docs/claude-code/README.md) | [安装](docs/claude-code/README.zh-CN.md) |
-| Cursor | [Setup](docs/cursor/README.md) | [安装](docs/cursor/README.zh-CN.md) |
-| OpenCode | [Setup](docs/opencode/README.md) | [安装](docs/opencode/README.zh-CN.md) |
-| OpenClaw | [Setup](docs/openclaw/README.md) | [安装](docs/openclaw/README.zh-CN.md) |
-| Pi | [Current limitation](docs/pi/README.md) | [当前限制](docs/pi/README.zh-CN.md) |
-| Other MCP hosts | [Setup](docs/other-hosts/README.md) | [安装](docs/other-hosts/README.zh-CN.md) |
+| ✏️ Editable | Every design stays editable in StarryKit—from individual elements to complete pages. |
+| 📤 Perfect export | Export complete documents or selected pages cleanly to PPTX, PDF, SVG, PNG, JPEG, HTML, or Google Slides. |
+| 💡 [Prompt Library](https://starrykit.com/explore) | Explore ready-to-use prompts and visual ideas, then open one in StarryKit to make it your own. |
 
 For maintainers, [development.md](docs/development.md) explains the repository checks and what the CI workflow does—and does not—test.
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,9 +13,8 @@
   <a href="#安装">安装</a> ·
   <a href="#看看实际效果">效果展示</a> ·
   <a href="#使用方法">使用方法</a> ·
-  <a href="#关键指标">关键指标</a> ·
   <a href="#功能">功能</a> ·
-  <a href="#手动安装">手动安装</a> ·
+  <a href="docs/README.zh-CN.md">手动安装</a> ·
   <a href="https://starrykit.com">官方网站</a>
 </p>
 
@@ -35,7 +34,7 @@ Skill: npx skills add StarryKit/starrykit-plugin --skill starrykit-authoring -g 
 MCP: https://mcp.starrykit.com/mcp
 ```
 
-Agent 会安装 Skill、配置 MCP 并打开浏览器 OAuth。需要手动操作时，请在[手动安装](#手动安装)中选择对应宿主。
+Agent 会安装 Skill、配置 MCP 并打开浏览器 OAuth。需要手动操作时，请打开[宿主安装指南](docs/README.zh-CN.md)。
 
 ## 看看实际效果
 
@@ -62,36 +61,13 @@ Agent 会安装 Skill、配置 MCP 并打开浏览器 OAuth。需要手动操作
 
 你也可以让 StarryKit 检查已有文档、收紧叙事、重新设计某一页、调整页面顺序，或者只导出指定页面。
 
-## 关键指标
-
-| ⚡ 一句 Prompt 安装 | 🧰 14 个 MCP 工具 | 📤 7 种导出格式 | 🔐 浏览器 OAuth |
-| --- | --- | --- | --- |
-| 同时配置 Skill 与 MCP | 读取、创作、预览与导出 | PPTX、PDF、SVG、PNG、JPEG、HTML、Google Slides | 无需粘贴 access token |
-
 ## 功能
 
-| 功能 | Agent 可以做什么 |
+| 功能 | 说明 |
 | --- | --- |
-| ✨ 视觉创作 | 创建演示文稿、海报、社交媒体图片、邀请函和其他可编辑设计。 |
-| 🔎 文档发现 | 只浏览你已经授权的 StarryKit 文档与文件夹。 |
-| 🎨 设计指导 | 建立清晰的信息层级、有意图的构图和针对每一页的视觉方向。 |
-| 🛠 精确修改 | 读取内容与预览，然后编辑、重写、改标题或移动正确的页面。 |
-| ✅ 草稿审核 | 每一张生成页面都交回 StarryKit，由你审核并决定是否采用。 |
-| 📤 灵活导出 | 将完整文档或指定页面导出为七种支持格式。 |
-
-## 手动安装
-
-如果 Agent 无法自动完成安装，请查看对应宿主的中英文指南：
-
-| 宿主 | 中文 | English |
-| --- | --- | --- |
-| Codex | [安装](docs/codex/README.zh-CN.md) | [Setup](docs/codex/README.md) |
-| Claude Code | [安装](docs/claude-code/README.zh-CN.md) | [Setup](docs/claude-code/README.md) |
-| Cursor | [安装](docs/cursor/README.zh-CN.md) | [Setup](docs/cursor/README.md) |
-| OpenCode | [安装](docs/opencode/README.zh-CN.md) | [Setup](docs/opencode/README.md) |
-| OpenClaw | [安装](docs/openclaw/README.zh-CN.md) | [Setup](docs/openclaw/README.md) |
-| Pi | [当前限制](docs/pi/README.zh-CN.md) | [Current limitation](docs/pi/README.md) |
-| 其他 MCP 宿主 | [安装](docs/other-hosts/README.zh-CN.md) | [Setup](docs/other-hosts/README.md) |
+| ✏️ 完整可编辑 | 所有 Design 都能在 StarryKit 中继续编辑，包括单个元素和完整页面。 |
+| 📤 完美导出 | 完整文档或指定页面都可以顺畅导出为 PPTX、PDF、SVG、PNG、JPEG、HTML 或 Google Slides。 |
+| 💡 [Prompt Library](https://starrykit.com/explore) | 浏览可以直接使用的 Prompt 与视觉灵感，并在 StarryKit 中打开、编辑成自己的作品。 |
 
 仓库维护者可以阅读 [development.md](docs/development.md)，了解 CI workflow 与测试实际覆盖和不覆盖的内容。
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,15 @@
+# Manual setup
+
+[中文](README.zh-CN.md) · [Back to StarryKit Plugin](../README.md)
+
+Choose your agent host:
+
+- [Codex](codex/README.md)
+- [Claude Code](claude-code/README.md)
+- [Cursor](cursor/README.md)
+- [OpenCode](opencode/README.md)
+- [OpenClaw](openclaw/README.md)
+- [Pi — current limitation](pi/README.md)
+- [Other MCP-compatible hosts](other-hosts/README.md)
+
+Every supported setup installs the same canonical `starrykit-authoring` Skill and connects to `https://mcp.starrykit.com/mcp` through the host's browser OAuth flow.

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -1,0 +1,15 @@
+# 手动安装
+
+[English](README.md) · [返回 StarryKit Plugin](../README.zh-CN.md)
+
+请选择你的 Agent 宿主：
+
+- [Codex](codex/README.zh-CN.md)
+- [Claude Code](claude-code/README.zh-CN.md)
+- [Cursor](cursor/README.zh-CN.md)
+- [OpenCode](opencode/README.zh-CN.md)
+- [OpenClaw](openclaw/README.zh-CN.md)
+- [Pi — 当前限制](pi/README.zh-CN.md)
+- [其他兼容 MCP 的宿主](other-hosts/README.zh-CN.md)
+
+所有支持的安装方式都会使用同一份 canonical `starrykit-authoring` Skill，并通过宿主的浏览器 OAuth 流程连接 `https://mcp.starrykit.com/mcp`。

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -81,6 +81,9 @@ describe("plugin bundle", () => {
     for (const path of ["README.md", "README.zh-CN.md"]) {
       assert.ok(existsSync(resolve(ROOT, path)), `${path} is missing`);
     }
+    for (const path of ["docs/README.md", "docs/README.zh-CN.md"]) {
+      assert.ok(existsSync(resolve(ROOT, path)), `${path} is missing`);
+    }
     for (const host of HOSTS) {
       assert.ok(existsSync(resolve(ROOT, "docs", host, "README.md")), `${host} English guide is missing`);
       assert.ok(existsSync(resolve(ROOT, "docs", host, "README.zh-CN.md")), `${host} Chinese guide is missing`);
@@ -92,6 +95,8 @@ describe("plugin bundle", () => {
     const markdownFiles = [
       "README.md",
       "README.zh-CN.md",
+      "docs/README.md",
+      "docs/README.zh-CN.md",
       "docs/development.md",
       ...HOSTS.flatMap((host) => [`docs/${host}/README.md`, `docs/${host}/README.zh-CN.md`]),
     ];


### PR DESCRIPTION
## What changed

- remove the Metrics section
- reduce Features to Editable, Perfect export, and Prompt Library
- link Prompt Library to the live StarryKit Explore page
- remove the Manual setup table from the project homepage
- point the header and install copy to a concise bilingual docs index

## Validation

- `npm test` (5/5 passing)
- `https://starrykit.com/explore` returns HTTP 200
- `git diff --check`