### PR TITLE
Streamline plugin validation and README

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -3,9 +3,6 @@ name: Plugin validation
 on:
   workflow_dispatch:
   pull_request:
-  push:
-    branches:
-      - main
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ You can also ask StarryKit to inspect an existing document, tighten its story, r
 | --- | --- |
 | ✏️ Editable | Every design stays editable in StarryKit—from individual elements to complete pages. |
 | 📤 Perfect export | Export complete documents or selected pages cleanly to PPTX, PDF, SVG, PNG, JPEG, HTML, or Google Slides. |
-| 💡 [Prompt Library](https://starrykit.com/explore) | Explore ready-to-use prompts and visual ideas, then open one in StarryKit to make it your own. |
+| 💡 1000+ Prompts | Explore [1,000+ ready-to-use prompts](https://starrykit.com/explore) and visual ideas, then open one in StarryKit to make it your own. |
 
-For maintainers, [development.md](docs/development.md) explains the repository checks and what the CI workflow does—and does not—test.
+---
 
 <sub>Historical note: this repository previously hosted Starry Slides. Its final source snapshot remains available on the <a href="https://github.com/StarryKit/starrykit-plugin/tree/archive/starry-slides-v0.1.38">archive/starry-slides-v0.1.38</a> branch.</sub>

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -67,8 +67,8 @@ Agent 会安装 Skill、配置 MCP 并打开浏览器 OAuth。需要手动操作
 | --- | --- |
 | ✏️ 完整可编辑 | 所有 Design 都能在 StarryKit 中继续编辑，包括单个元素和完整页面。 |
 | 📤 完美导出 | 完整文档或指定页面都可以顺畅导出为 PPTX、PDF、SVG、PNG、JPEG、HTML 或 Google Slides。 |
-| 💡 [Prompt Library](https://starrykit.com/explore) | 浏览可以直接使用的 Prompt 与视觉灵感，并在 StarryKit 中打开、编辑成自己的作品。 |
+| 💡 1000+ Prompts | 浏览 [1,000+ 个可以直接使用的 Prompt](https://starrykit.com/explore) 与视觉灵感，并在 StarryKit 中打开、编辑成自己的作品。 |
 
-仓库维护者可以阅读 [development.md](docs/development.md)，了解 CI workflow 与测试实际覆盖和不覆盖的内容。
+---
 
 <sub>历史说明：这个仓库过去用于 Starry Slides。最终源码快照仍保存在 <a href="https://github.com/StarryKit/starrykit-plugin/tree/archive/starry-slides-v0.1.38">archive/starry-slides-v0.1.38</a> 分支。</sub>

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,18 +4,18 @@ This repository is the installable client-side StarryKit Plugin bundle. It conta
 
 ## What the workflow means
 
-`.github/workflows/validation.yml` runs `npm test` for pull requests and pushes to `main`. It is a repository-integrity guard, not a deployment workflow and not a live MCP health check.
+`.github/workflows/validation.yml` runs `npm test` for pull requests and on manual dispatch. It is a repository-integrity guard, not a deployment workflow and not a live MCP health check.
 
 The test verifies that:
 
 - the Codex and Claude manifests describe the same plugin release;
 - the bundled MCP config points to the production HTTPS endpoint without embedded credentials;
-- the canonical Skill mentions the complete public tool set and preserves important design and safety boundaries;
+- the canonical Skill has valid metadata, references the production MCP endpoint, and preserves essential safety boundaries;
 - English and Chinese user docs exist for every documented host;
 - local Markdown links and media links resolve;
 - the removed `hosts/` compatibility layer does not return.
 
-This makes accidental packaging drift visible in a pull request without maintaining a second copy of the server's tool schemas.
+This makes accidental packaging drift visible in a pull request without duplicating the server's tool schema or coupling harmless Skill copy changes to CI.
 
 ## What it does not test
 
@@ -26,5 +26,3 @@ Run the local check with:
 ```sh
 npm test
 ```
-
-When the Hosted MCP adds or removes a public tool, update the canonical Skill and the expected tool-name set in `tests/plugin.test.mjs` together.

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -5,22 +5,6 @@ import { describe, it } from "node:test";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const PRODUCTION_MCP_URL = "https://mcp.starrykit.com/mcp";
-const TOOL_NAMES = [
-  "list_documents",
-  "read_document",
-  "preview_page",
-  "create_document",
-  "get_profile_catalog",
-  "insert_pages",
-  "rewrite_pages",
-  "edit_pages",
-  "get_authoring_statuses",
-  "update_document_title",
-  "update_page_titles",
-  "move_page",
-  "export_document",
-  "get_export_status",
-];
 const HOSTS = ["codex", "claude-code", "cursor", "opencode", "openclaw", "pi", "other-hosts"];
 
 function read(path) {
@@ -58,17 +42,13 @@ describe("plugin bundle", () => {
     }
   });
 
-  it("ships one design-directed canonical Skill for the public tool set", () => {
+  it("ships a valid canonical Skill with essential safety boundaries", () => {
     const skill = read("skills/starrykit-authoring/SKILL.md");
 
-    for (const tool of TOOL_NAMES) {
-      assert.ok(skill.includes(`\`${tool}\``), `Skill does not document ${tool}`);
-    }
-
+    assert.match(skill, /^---\nname: starrykit-authoring\ndescription: .+\n---\n/);
+    assert.match(skill, /# StarryKit Authoring/);
+    assert.ok(skill.includes(PRODUCTION_MCP_URL), "Skill must reference the production MCP endpoint");
     for (const boundary of [
-      "Act as the Design Director",
-      "one dominant idea",
-      "negative space",
       "Never invoke or delegate to a private StarryKit Main Agent",
       "Do not accept, keep, commit, reject, discard, or drop a Page Draft",
       "A read-only grant rejects every write tool",


### PR DESCRIPTION
## Summary
- slim plugin validation to stable packaging and safety checks
- run validation on pull requests or manual dispatch only
- refine the bilingual README features and historical-note layout

## Verification
- npm test
- git diff --check