### PR TITLE
Add StarryKit plugin marketplaces

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,20 @@
+{
+  "name": "starrykit",
+  "interface": {
+    "displayName": "StarryKit"
+  },
+  "plugins": [
+    {
+      "name": "starrykit-plugin",
+      "source": {
+        "source": "local",
+        "path": "./"
+      },
+      "policy": {
+        "installation": "AVAILABLE",
+        "authentication": "ON_INSTALL"
+      },
+      "category": "Creativity"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-marketplace.json",
+  "name": "starrykit",
+  "description": "Create editable presentations, posters, social graphics, art, and visual design documents with StarryKit.",
+  "owner": {
+    "name": "StarryKit",
+    "url": "https://starrykit.com"
+  },
+  "plugins": [
+    {
+      "name": "starrykit-plugin",
+      "source": "./",
+      "description": "Create editable presentations, posters, social graphics, art, and visual design documents from prompts and references.",
+      "version": "0.4.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,14 +1,33 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "starrykit-plugin",
-  "displayName": "StarryKit Plugin",
-  "version": "0.1.0",
-  "description": "Turn ideas into polished, editable visual design documents with StarryKit.",
+  "displayName": "StarryKit",
+  "version": "0.4.0",
+  "description": "Create editable presentations, posters, social graphics, art, and visual design documents from prompts and references.",
   "author": {
     "name": "StarryKit",
-    "url": "https://github.com/StarryKit"
+    "url": "https://starrykit.com"
   },
-  "homepage": "https://github.com/StarryKit/starrykit-plugin",
+  "homepage": "https://starrykit.com",
   "repository": "https://github.com/StarryKit/starrykit-plugin",
   "license": "MIT",
-  "keywords": ["starrykit", "authoring", "documents", "mcp"]
+  "keywords": [
+    "starrykit",
+    "ai-design",
+    "ai-presentation-maker",
+    "ai-poster-maker",
+    "presentation",
+    "poster",
+    "visual-design",
+    "graphic-design",
+    "art",
+    "social-media",
+    "infographic",
+    "diagram",
+    "editable-design",
+    "pptx",
+    "google-slides"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,27 +1,49 @@
 {
   "name": "starrykit-plugin",
-  "version": "0.1.0",
-  "description": "Turn ideas into polished, editable visual design documents with StarryKit.",
+  "version": "0.4.0",
+  "description": "Create editable presentations, posters, social graphics, art, and visual design documents from prompts and references.",
   "author": {
     "name": "StarryKit",
-    "url": "https://github.com/StarryKit"
+    "url": "https://starrykit.com"
   },
-  "homepage": "https://github.com/StarryKit/starrykit-plugin",
+  "homepage": "https://starrykit.com",
   "repository": "https://github.com/StarryKit/starrykit-plugin",
   "license": "MIT",
-  "keywords": ["starrykit", "authoring", "documents", "mcp"],
+  "keywords": [
+    "starrykit",
+    "ai-design",
+    "ai-presentation-maker",
+    "ai-poster-maker",
+    "presentation",
+    "poster",
+    "visual-design",
+    "graphic-design",
+    "art",
+    "social-media",
+    "infographic",
+    "diagram",
+    "editable-design",
+    "pptx",
+    "google-slides"
+  ],
   "skills": "./skills/",
   "interface": {
-    "displayName": "StarryKit Plugin",
-    "shortDescription": "Create polished visual design documents.",
-    "longDescription": "Create, understand, and refine presentations, posters, social graphics, and other editable visual design documents with StarryKit's hosted design tools.",
+    "displayName": "StarryKit",
+    "shortDescription": "Create and edit visual designs",
+    "longDescription": "StarryKit turns prompts and references into polished, editable visual documents. Create presentations, posters, social graphics, infographics, diagrams, cards, email designs, web and UI concepts, and visual art; refine every element with AI or direct editing, then export to PPTX, PDF, Google Slides, SVG, PNG, JPEG, or HTML.",
     "developerName": "StarryKit",
-    "category": "Productivity",
-    "capabilities": ["Read", "Write"],
+    "category": "Creativity",
+    "capabilities": ["Interactive", "Read", "Write"],
+    "websiteURL": "https://starrykit.com",
+    "privacyPolicyURL": "https://starrykit.com/privacy",
+    "termsOfServiceURL": "https://starrykit.com/terms",
     "defaultPrompt": [
-      "Turn my idea into a polished StarryKit presentation.",
-      "Review my StarryKit design document and refine one page."
-    ]
+      "Create a 10-slide pitch deck for a sustainable urban farming startup raising a seed round",
+      "Design a bold launch poster for a midnight electronic music festival in Tokyo",
+      "Recreate the attached coffee shop landing page screenshot as an editable visual design"
+    ],
+    "brandColor": "#6D5DF6",
+    "composerIcon": "./assets/brand/starrykit-logo.svg"
   },
   "mcpServers": "./.mcp.json"
 }

--- a/README.md
+++ b/README.md
@@ -10,31 +10,44 @@
 
 <p align="center">
   <a href="README.zh-CN.md">简体中文</a> ·
+  <a href="#overview">Overview</a> ·
   <a href="#install">Install</a> ·
   <a href="#see-it-in-action">Demos</a> ·
   <a href="#use-cases">Use cases</a> ·
-  <a href="#features">Features</a> ·
   <a href="docs/README.md">Manual setup</a> ·
   <a href="https://starrykit.com">Website</a>
 </p>
 
-StarryKit turns your AI agent into a visual co-creator:
+## Overview
 
-- ✨ Go from a prompt to a polished presentation, poster, or social graphic.
-- 🎨 Keep every page fully editable and review each draft in StarryKit.
-- 🔌 Use one shared Skill and Hosted MCP across Codex, Claude Code, Cursor, OpenCode, OpenClaw, and more.
+StarryKit gives your AI agent a complete visual design workflow. Start with an idea, image, website, or source file; create a polished visual document; refine every element; and export it in the format you need. You do not need to find the right template first—your references become the starting point.
+
+| Feature | What it means |
+| --- | --- |
+| **Editable** | Every design stays editable in StarryKit—from individual elements to complete pages. |
+| **Perfect export** | Export complete documents or selected pages cleanly to PPTX, PDF, SVG, PNG, JPEG, HTML, or Google Slides. |
+| **Import & recreate** | Provide an image, a website, or a source file such as `design.md`. StarryKit uses it as a visual reference and recreates it as an editable design—no template required. |
+| **1000+ Prompts** | Explore [1,000+ ready-to-use prompts](https://starrykit.com/explore) and visual ideas, then open one in StarryKit to make it your own. |
 
 ## Install
 
-Send this to your agent:
+StarryKit is not yet listed in the official plugin directories. Add the StarryKit marketplace, then install the plugin directly from it.
 
-```text
-Set up StarryKit for this agent.
-Skill: npx skills add StarryKit/starrykit-plugin --skill starrykit -g -y
-MCP: https://mcp.starrykit.com/mcp
+### Claude Code
+
+```bash
+claude plugin marketplace add StarryKit/starrykit-plugin
+claude plugin install starrykit-plugin@starrykit
 ```
 
-Your agent installs the Skill, configures the MCP, and opens browser OAuth. If needed, open the [manual setup guides](docs/README.md).
+### Codex
+
+```bash
+codex plugin marketplace add StarryKit/starrykit-plugin
+codex plugin add starrykit-plugin@starrykit
+```
+
+The plugin installs the StarryKit Skill and configures the Hosted MCP. Browser OAuth opens when your agent connects for the first time. For other hosts or manual setup, see the [installation guides](docs/README.md).
 
 ## See it in action
 
@@ -83,15 +96,6 @@ Your agent installs the Skill, configures the MCP, and opens browser OAuth. If n
 | <img src="assets/demos/gallery-infographic-reform.webp" alt="Circular materials infographic created with StarryKit" width="280" /> | <img src="assets/demos/gallery-email-green-hour.webp" alt="Editorial product email created with StarryKit" width="280" /> | <img src="assets/demos/gallery-email-decision-drag.webp" alt="Research briefing email created with StarryKit" width="280" /> |
 
 [Explore more work in the StarryKit Gallery.](https://starrykit.com/gallery)
-
-## Features
-
-| Feature | What it means |
-| --- | --- |
-| **Editable** | Every design stays editable in StarryKit—from individual elements to complete pages. |
-| **Perfect export** | Export complete documents or selected pages cleanly to PPTX, PDF, SVG, PNG, JPEG, HTML, or Google Slides. |
-| **Import & recreate** | Provide an image, a website, or a source file such as `design.md`. StarryKit uses it as a visual reference and recreates it as an editable design—no template required. |
-| **1000+ Prompts** | Explore [1,000+ ready-to-use prompts](https://starrykit.com/explore) and visual ideas, then open one in StarryKit to make it your own. |
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,31 +10,44 @@
 
 <p align="center">
   <a href="README.md">English</a> ·
+  <a href="#概览">概览</a> ·
   <a href="#安装">安装</a> ·
   <a href="#看看实际效果">效果展示</a> ·
   <a href="#使用场景">使用场景</a> ·
-  <a href="#功能">功能</a> ·
   <a href="docs/README.zh-CN.md">手动安装</a> ·
   <a href="https://starrykit.com">官方网站</a>
 </p>
 
-StarryKit 让你的 AI Agent 直接拥有视觉创作能力：
+## 概览
 
-- ✨ 从一句 Prompt 开始，完成演示文稿、海报或社交媒体图片。
-- 🎨 所有页面保持完整可编辑，每一份草稿都可以在 StarryKit 中审核。
-- 🔌 一套 Skill 与 Hosted MCP，同时支持 Codex、Claude Code、Cursor、OpenCode、OpenClaw 等宿主。
+StarryKit 为你的 AI Agent 提供完整的视觉设计工作流。从一个想法、一张图片、一个网站或源文件开始，创建精致的视觉文档，继续调整每个元素，并导出为需要的格式。你不需要先找到合适的模板——任何参考素材都可以成为设计的起点。
+
+| 功能 | 说明 |
+| --- | --- |
+| **完整可编辑** | 所有 Design 都能在 StarryKit 中继续编辑，包括单个元素和完整页面。 |
+| **完美导出** | 完整文档或指定页面都可以顺畅导出为 PPTX、PDF、SVG、PNG、JPEG、HTML 或 Google Slides。 |
+| **导入与复刻** | 提供一张图片、一个网站，或 `design.md` 等源文件。StarryKit 会把它作为视觉参考，复刻成可编辑的设计，不需要预先准备模板。 |
+| **1000+ Prompts** | 浏览 [1,000+ 个可以直接使用的 Prompt](https://starrykit.com/explore) 与视觉灵感，并在 StarryKit 中打开、编辑成自己的作品。 |
 
 ## 安装
 
-把这一段发送给你的 Agent：
+StarryKit 尚未进入官方 Plugin 市场。请先添加 StarryKit Marketplace，再从中安装 Plugin。
 
-```text
-请为当前 Agent 配置 StarryKit。
-Skill: npx skills add StarryKit/starrykit-plugin --skill starrykit -g -y
-MCP: https://mcp.starrykit.com/mcp
+### Claude Code
+
+```bash
+claude plugin marketplace add StarryKit/starrykit-plugin
+claude plugin install starrykit-plugin@starrykit
 ```
 
-Agent 会安装 Skill、配置 MCP 并打开浏览器 OAuth。需要手动操作时，请打开[宿主安装指南](docs/README.zh-CN.md)。
+### Codex
+
+```bash
+codex plugin marketplace add StarryKit/starrykit-plugin
+codex plugin add starrykit-plugin@starrykit
+```
+
+Plugin 会安装 StarryKit Skill 并配置 Hosted MCP。Agent 第一次连接时会打开浏览器完成 OAuth。其他宿主或手动配置方式请查看[安装指南](docs/README.zh-CN.md)。
 
 ## 看看实际效果
 
@@ -83,15 +96,6 @@ Agent 会安装 Skill、配置 MCP 并打开浏览器 OAuth。需要手动操作
 | <img src="assets/demos/gallery-infographic-reform.webp" alt="使用 StarryKit 创建的循环材料信息图" width="280" /> | <img src="assets/demos/gallery-email-green-hour.webp" alt="使用 StarryKit 创建的编辑风格产品邮件" width="280" /> | <img src="assets/demos/gallery-email-decision-drag.webp" alt="使用 StarryKit 创建的研究简报邮件" width="280" /> |
 
 [前往 StarryKit Gallery 查看更多作品。](https://starrykit.com/gallery)
-
-## 功能
-
-| 功能 | 说明 |
-| --- | --- |
-| **完整可编辑** | 所有 Design 都能在 StarryKit 中继续编辑，包括单个元素和完整页面。 |
-| **完美导出** | 完整文档或指定页面都可以顺畅导出为 PPTX、PDF、SVG、PNG、JPEG、HTML 或 Google Slides。 |
-| **导入与复刻** | 提供一张图片、一个网站，或 `design.md` 等源文件。StarryKit 会把它作为视觉参考，复刻成可编辑的设计，不需要预先准备模板。 |
-| **1000+ Prompts** | 浏览 [1,000+ 个可以直接使用的 Prompt](https://starrykit.com/explore) 与视觉灵感，并在 StarryKit 中打开、编辑成自己的作品。 |
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "starrykit-plugin",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "description": "StarryKit Plugin manifests, canonical StarryKit Skill, and user setup guides.",
   "scripts": {

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -19,13 +19,49 @@ describe("plugin bundle", () => {
   it("keeps the manifests aligned", () => {
     const codex = json(".codex-plugin/plugin.json");
     const claude = json(".claude-plugin/plugin.json");
+    const packageManifest = json("package.json");
 
     assert.equal(codex.name, "starrykit-plugin");
     assert.equal(claude.name, codex.name);
     assert.equal(claude.version, codex.version);
+    assert.equal(packageManifest.version, codex.version);
+    assert.equal(codex.interface.displayName, "StarryKit");
+    assert.equal(claude.displayName, "StarryKit");
+    assert.deepEqual(claude.author, codex.author);
+    assert.equal(claude.homepage, codex.homepage);
+    assert.equal(claude.repository, codex.repository);
     assert.equal(codex.license, "MIT");
     assert.equal(claude.license, "MIT");
     assert.equal(codex.mcpServers, "./.mcp.json");
+    assert.equal(claude.mcpServers, "./.mcp.json");
+    assert.equal(claude.skills, "./skills/");
+  });
+
+  it("provides concise Codex discovery metadata and starter prompts", () => {
+    const { interface: metadata } = json(".codex-plugin/plugin.json");
+
+    assert.ok(metadata.displayName.length <= 30);
+    assert.ok(metadata.shortDescription.length <= 30);
+    assert.ok(metadata.defaultPrompt.length > 0 && metadata.defaultPrompt.length <= 3);
+    for (const prompt of metadata.defaultPrompt) {
+      assert.ok(prompt.length <= 128, `default prompt is too long: ${prompt}`);
+    }
+    assert.equal(metadata.websiteURL, "https://starrykit.com");
+    assert.equal(metadata.privacyPolicyURL, "https://starrykit.com/privacy");
+    assert.equal(metadata.termsOfServiceURL, "https://starrykit.com/terms");
+  });
+
+  it("publishes installable Claude and Codex marketplace catalogs", () => {
+    const codexMarketplace = json(".agents/plugins/marketplace.json");
+    const claudeMarketplace = json(".claude-plugin/marketplace.json");
+
+    assert.equal(codexMarketplace.name, "starrykit");
+    assert.equal(claudeMarketplace.name, "starrykit");
+    assert.equal(codexMarketplace.plugins[0].name, "starrykit-plugin");
+    assert.equal(claudeMarketplace.plugins[0].name, "starrykit-plugin");
+    assert.equal(codexMarketplace.plugins[0].source.path, "./");
+    assert.equal(claudeMarketplace.plugins[0].source, "./");
+    assert.equal(claudeMarketplace.plugins[0].version, json(".claude-plugin/plugin.json").version);
   });
 
   it("uses the production Hosted MCP without embedded credentials", () => {


### PR DESCRIPTION
## Summary

- refresh Claude and Codex plugin metadata and starter prompts
- add StarryKit-owned marketplace catalogs for both hosts
- reorganize the bilingual README around overview, features, and direct installation

## Validation

- `npm test`
- `claude plugin validate . --strict`
- `python3 /home/haichao/.codex/skills/.system/plugin-creator/scripts/validate_plugin.py .`
- `git diff --check`
