### PR TITLE
chore: ignore app submission artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 __pycache__/
 *.py[cod]
 .DS_Store
+chatgpt-app-submission.json


### PR DESCRIPTION
Ignore the locally generated ChatGPT app submission artifact so it can be uploaded to the submission portal without entering the repository.