### PR TITLE
Connect StarryKit plugin to registered app

### DIFF
--- a/.app.json
+++ b/.app.json
@@ -1,0 +1,8 @@
+{
+  "apps": {
+    "starrykit": {
+      "id": "asdk_app_6a7d4856434081919523a0971a413bb4",
+      "required": true
+    }
+  }
+}

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -46,5 +46,6 @@
     "composerIcon": "./assets/brand/starrykit-logo.svg",
     "logo": "./assets/brand/starrykit-app-icon.png"
   },
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "apps": "./.app.json"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ __pycache__/
 *.py[cod]
 .DS_Store
 chatgpt-app-submission.json
+.local/set-openai-domain-challenge.zsh

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const PRODUCTION_MCP_URL = "https://mcp.starrykit.com/mcp";
+const DEVELOPMENT_APP_ID = "asdk_app_6a7d4856434081919523a0971a413bb4";
 const HOSTS = ["codex", "claude-code", "cursor", "opencode", "openclaw", "pi", "other-hosts"];
 
 function read(path) {
@@ -33,8 +34,22 @@ describe("plugin bundle", () => {
     assert.equal(codex.license, "MIT");
     assert.equal(claude.license, "MIT");
     assert.equal(codex.mcpServers, "./.mcp.json");
+    assert.equal(codex.apps, "./.app.json");
     assert.equal(claude.mcpServers, "./.mcp.json");
     assert.equal(claude.skills, "./skills/");
+  });
+
+  it("installs the registered StarryKit app with the Codex plugin", () => {
+    const app = json(".app.json");
+
+    assert.deepEqual(app, {
+      apps: {
+        starrykit: {
+          id: DEVELOPMENT_APP_ID,
+          required: true,
+        },
+      },
+    });
   });
 
   it("provides concise Codex discovery metadata and starter prompts", () => {


### PR DESCRIPTION
## Summary

- add the registered StarryKit Developer Mode app mapping
- load the app through the Codex plugin manifest
- require the app when installing the plugin
- preserve local-only submission and domain challenge artifacts in gitignore
- add contract coverage for the app mapping

## Validation

- `npm test` (8 tests passed)
- `git diff --check`

## Note

The bundled plugin-creator validator currently rejects `required`, although current OpenAI curated plugins use `required: true`; the repository contract test covers the intended current manifest shape.