### PR TITLE
Add native Grok plugin support

### DIFF
--- a/.grok-plugin/plugin.json
+++ b/.grok-plugin/plugin.json
@@ -1,0 +1,22 @@
+{
+  "name": "starrykit-plugin",
+  "displayName": "StarryKit",
+  "version": "0.4.0",
+  "description": "Turn ideas and visual references into polished, editable presentations, posters, social graphics, infographics, diagrams, and visual documents in Grok Build. Refine every element, review AI-generated drafts, and export to PowerPoint, PDF, Google Slides, SVG, PNG, JPEG, or HTML.",
+  "author": {
+    "name": "StarryKit",
+    "url": "https://starrykit.com"
+  },
+  "homepage": "https://starrykit.com",
+  "repository": "https://github.com/StarryKit/starrykit-plugin",
+  "license": "MIT",
+  "keywords": [
+    "starrykit",
+    "starrykit-design",
+    "starrykit-presentations",
+    "starrykit-visual-documents"
+  ],
+  "logo": "assets/brand/starrykit-app-icon.png",
+  "skills": "./skills/",
+  "mcpServers": "./.mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ StarryKit gives your AI agent a complete visual design workflow. Start with an i
 
 ## Install
 
-StarryKit is not yet listed in the official plugin directories. Add the StarryKit marketplace, then install the plugin directly from it.
+Install StarryKit for your preferred agent host.
 
 ### Claude Code
 
@@ -45,6 +45,12 @@ claude plugin install starrykit-plugin@starrykit
 ```bash
 codex plugin marketplace add StarryKit/starrykit-plugin
 codex plugin add starrykit-plugin@starrykit
+```
+
+### Grok Build
+
+```bash
+grok plugin install StarryKit/starrykit-plugin --trust
 ```
 
 The plugin installs the StarryKit Skill and configures the Hosted MCP. Browser OAuth opens when your agent connects for the first time. For other hosts or manual setup, see the [installation guides](docs/README.md).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@ StarryKit 为你的 AI Agent 提供完整的视觉设计工作流。从一个想
 
 ## 安装
 
-StarryKit 尚未进入官方 Plugin 市场。请先添加 StarryKit Marketplace，再从中安装 Plugin。
+请根据你使用的 Agent 宿主安装 StarryKit。
 
 ### Claude Code
 
@@ -45,6 +45,12 @@ claude plugin install starrykit-plugin@starrykit
 ```bash
 codex plugin marketplace add StarryKit/starrykit-plugin
 codex plugin add starrykit-plugin@starrykit
+```
+
+### Grok Build
+
+```bash
+grok plugin install StarryKit/starrykit-plugin --trust
 ```
 
 Plugin 会安装 StarryKit Skill 并配置 Hosted MCP。Agent 第一次连接时会打开浏览器完成 OAuth。其他宿主或手动配置方式请查看[安装指南](docs/README.zh-CN.md)。

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ Choose your agent host:
 
 - [Codex](codex/README.md)
 - [Claude Code](claude-code/README.md)
+- [Grok Build](grok-build/README.md)
 - [Cursor](cursor/README.md)
 - [OpenCode](opencode/README.md)
 - [OpenClaw](openclaw/README.md)

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -6,6 +6,7 @@
 
 - [Codex](codex/README.zh-CN.md)
 - [Claude Code](claude-code/README.zh-CN.md)
+- [Grok Build](grok-build/README.zh-CN.md)
 - [Cursor](cursor/README.zh-CN.md)
 - [OpenCode](opencode/README.zh-CN.md)
 - [OpenClaw](openclaw/README.zh-CN.md)

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ This repository is the installable client-side StarryKit Plugin bundle. It conta
 
 The test verifies that:
 
-- the Codex and Claude manifests describe the same plugin release;
+- the Codex, Claude, and Grok manifests keep the same release identity and component paths while allowing host-specific marketing copy;
 - the bundled MCP config points to the production HTTPS endpoint without embedded credentials;
 - the canonical Skill has valid metadata, references the production MCP endpoint, and preserves essential safety boundaries;
 - English and Chinese user docs exist for every documented host;

--- a/docs/grok-build/README.md
+++ b/docs/grok-build/README.md
@@ -1,0 +1,38 @@
+# Install StarryKit in Grok Build
+
+[中文](README.zh-CN.md) · [All installation guides](../README.md)
+
+Install the StarryKit Plugin directly from its public GitHub repository:
+
+```bash
+grok plugin install StarryKit/starrykit-plugin --trust
+```
+
+`--trust` allows Grok Build to activate the Hosted MCP bundled with the Plugin. StarryKit does not include local executables, hooks, or embedded credentials; its only MCP connection is the production endpoint at `https://mcp.starrykit.com/mcp`.
+
+## Connect your account
+
+Start Grok Build, open `/mcps`, select `starrykit`, and complete the browser OAuth flow. Do not paste an API token or client secret into the Plugin configuration.
+
+## Verify the installation
+
+Start a new session and ask:
+
+```text
+Use StarryKit to list my recent visual documents.
+```
+
+The connection is ready when Grok Build can call `list_documents` and return your authorized documents, or an empty result without an authentication error.
+
+## Troubleshooting
+
+Inspect the installed Plugin with:
+
+```bash
+grok plugin details starrykit-plugin
+grok inspect --json
+```
+
+If the MCP is disabled, open `/plugins` and trust the Plugin, or reinstall it with `--trust`.
+
+Official reference: [Grok Build plugins, skills, and marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces).

--- a/docs/grok-build/README.zh-CN.md
+++ b/docs/grok-build/README.zh-CN.md
@@ -1,0 +1,38 @@
+# 在 Grok Build 中安装 StarryKit
+
+[English](README.md) · [全部安装指南](../README.zh-CN.md)
+
+直接从 StarryKit 的公开 GitHub 仓库安装 Plugin：
+
+```bash
+grok plugin install StarryKit/starrykit-plugin --trust
+```
+
+`--trust` 允许 Grok Build 启用 Plugin 中配置的 Hosted MCP。StarryKit 不包含本地可执行文件、Hook 或内嵌凭据；它只会连接生产 MCP 地址 `https://mcp.starrykit.com/mcp`。
+
+## 连接账号
+
+启动 Grok Build，打开 `/mcps`，选择 `starrykit`，然后在浏览器中完成 OAuth。不要把 API token 或 client secret 写入 Plugin 配置。
+
+## 验证安装
+
+新建一个会话并发送：
+
+```text
+使用 StarryKit 列出我最近的视觉文档。
+```
+
+当 Grok Build 能调用 `list_documents`，并返回已授权文档或没有认证错误的空结果时，连接即完成。
+
+## 排查问题
+
+使用下面的命令检查已安装的 Plugin：
+
+```bash
+grok plugin details starrykit-plugin
+grok inspect --json
+```
+
+如果 MCP 被禁用，请在 `/plugins` 中信任该 Plugin，或使用 `--trust` 重新安装。
+
+官方参考：[Grok Build Plugins、Skills 与 Marketplaces](https://docs.x.ai/build/features/skills-plugins-marketplaces)。

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -6,7 +6,7 @@ import { describe, it } from "node:test";
 const ROOT = resolve(import.meta.dirname, "..");
 const PRODUCTION_MCP_URL = "https://mcp.starrykit.com/mcp";
 const DEVELOPMENT_APP_ID = "asdk_app_6a7d4856434081919523a0971a413bb4";
-const HOSTS = ["codex", "claude-code", "cursor", "opencode", "openclaw", "pi", "other-hosts"];
+const HOSTS = ["codex", "claude-code", "grok-build", "cursor", "opencode", "openclaw", "pi", "other-hosts"];
 
 function read(path) {
   return readFileSync(resolve(ROOT, path), "utf8");
@@ -20,23 +20,36 @@ describe("plugin bundle", () => {
   it("keeps the manifests aligned", () => {
     const codex = json(".codex-plugin/plugin.json");
     const claude = json(".claude-plugin/plugin.json");
+    const grok = json(".grok-plugin/plugin.json");
     const packageManifest = json("package.json");
 
     assert.equal(codex.name, "starrykit-plugin");
     assert.equal(claude.name, codex.name);
+    assert.equal(grok.name, codex.name);
     assert.equal(claude.version, codex.version);
+    assert.equal(grok.version, codex.version);
     assert.equal(packageManifest.version, codex.version);
     assert.equal(codex.interface.displayName, "StarryKit");
     assert.equal(claude.displayName, "StarryKit");
+    assert.equal(grok.displayName, "StarryKit");
     assert.deepEqual(claude.author, codex.author);
+    assert.deepEqual(grok.author, codex.author);
     assert.equal(claude.homepage, codex.homepage);
+    assert.equal(grok.homepage, codex.homepage);
     assert.equal(claude.repository, codex.repository);
+    assert.equal(grok.repository, codex.repository);
     assert.equal(codex.license, "MIT");
     assert.equal(claude.license, "MIT");
+    assert.equal(grok.license, "MIT");
     assert.equal(codex.mcpServers, "./.mcp.json");
     assert.equal(codex.apps, "./.app.json");
     assert.equal(claude.mcpServers, "./.mcp.json");
+    assert.equal(grok.mcpServers, "./.mcp.json");
     assert.equal(claude.skills, "./skills/");
+    assert.equal(grok.skills, "./skills/");
+    assert.notEqual(grok.description, claude.description, "Grok copy should remain host-specific");
+    assert.equal(grok.logo, "assets/brand/starrykit-app-icon.png");
+    assert.ok(existsSync(resolve(ROOT, grok.logo)));
   });
 
   it("installs the registered StarryKit app with the Codex plugin", () => {


### PR DESCRIPTION
## Summary
- add a native `.grok-plugin/plugin.json` with Grok-specific discovery copy
- document Grok Build installation, OAuth, verification, and troubleshooting in English and Chinese
- lock shared release identity, Skill path, MCP path, and production endpoint against cross-host drift

## Validation
- `npm test`
- `grok plugin validate .`
- `claude plugin validate . --strict`