### PR TITLE
Add native Cursor plugin support

### DIFF
--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,36 @@
+{
+  "name": "starrykit-plugin",
+  "displayName": "StarryKit",
+  "version": "0.4.0",
+  "minClientVersions": {
+    "cursor": "3.13.0"
+  },
+  "description": "Bring visual design into Cursor. Turn prompts, images, websites, and source files into polished, editable presentations, posters, social graphics, infographics, diagrams, and visual documents; refine every element with AI, then export to PowerPoint, PDF, Google Slides, SVG, PNG, JPEG, or HTML.",
+  "author": {
+    "name": "StarryKit"
+  },
+  "homepage": "https://starrykit.com",
+  "repository": "https://github.com/StarryKit/starrykit-plugin",
+  "license": "MIT",
+  "logo": "assets/brand/starrykit-app-icon.png",
+  "keywords": [
+    "starrykit",
+    "ai-presentation-maker",
+    "ai-poster-maker",
+    "visual-design",
+    "editable-design",
+    "social-graphics",
+    "infographics",
+    "diagrams"
+  ],
+  "category": "productivity",
+  "tags": [
+    "presentations",
+    "posters",
+    "visual-documents",
+    "design",
+    "mcp"
+  ],
+  "skills": "./skills/",
+  "mcpServers": "./mcp.json"
+}

--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ codex plugin marketplace add StarryKit/starrykit-plugin
 codex plugin add starrykit-plugin@starrykit
 ```
 
+### Cursor
+
+Open `/add-plugin` in Cursor and search for **StarryKit**. While the Marketplace listing is under review, use the [manual Cursor setup](docs/cursor/README.md).
+
 ### Grok Build
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -47,6 +47,10 @@ codex plugin marketplace add StarryKit/starrykit-plugin
 codex plugin add starrykit-plugin@starrykit
 ```
 
+### Cursor
+
+在 Cursor 中打开 `/add-plugin`，搜索 **StarryKit**。Marketplace 上架审核期间，请使用 [Cursor 手动安装指南](docs/cursor/README.zh-CN.md)。
+
 ### Grok Build
 
 ```bash

--- a/docs/cursor/README.md
+++ b/docs/cursor/README.md
@@ -2,9 +2,15 @@
 
 [中文](README.zh-CN.md) · [Back to the Plugin](../../README.md)
 
-## 1. Install the Skill
+## Install from the Cursor Marketplace
 
-Clone this repository and copy the canonical Skill into a Cursor-supported personal location:
+Open `/add-plugin` in Cursor, search for **StarryKit**, and select **Install**. Cursor installs the canonical StarryKit Skill and configures the Hosted MCP together.
+
+The Marketplace listing is currently under review. Until it is available, use the manual setup below.
+
+## Manual setup
+
+Clone this repository and copy the canonical Skill into Cursor's personal Skill directory:
 
 ```sh
 git clone https://github.com/StarryKit/starrykit-plugin.git
@@ -12,21 +18,22 @@ mkdir -p ~/.cursor/skills
 cp -R starrykit-plugin/skills/starrykit ~/.cursor/skills/
 ```
 
-## 2. Configure MCP
-
-Add this entry to your global `~/.cursor/mcp.json`, or to `.cursor/mcp.json` for one project:
+Then add this entry to global `~/.cursor/mcp.json`, or to `.cursor/mcp.json` for one project:
 
 ```json
 {
   "mcpServers": {
     "starrykit": {
+      "type": "http",
       "url": "https://mcp.starrykit.com/mcp"
     }
   }
 }
 ```
 
-Open Cursor's MCP settings and complete OAuth when prompted. Cursor Agent CLI users can run:
+## Connect your account
+
+Open Cursor's MCP settings and complete browser OAuth when prompted. Cursor Agent CLI users can run:
 
 ```sh
 cursor-agent mcp login starrykit
@@ -35,8 +42,8 @@ cursor-agent mcp list-tools starrykit
 
 Do not add credentials or static Authorization headers.
 
-## 3. Verify
+## Verify
 
-Ask Cursor Agent to use StarryKit to list the visual documents you can access. The setup is ready when it can call `list_documents`.
+Ask Cursor Agent to use StarryKit to list the visual documents you can access. The setup is ready when it can call `list_documents` and returns your authorized documents, or an empty result without an authentication error.
 
-Official references: [Cursor MCP](https://cursor.com/docs/context/mcp), [Cursor Agent CLI MCP commands](https://cursor.com/docs/cli/reference/parameters), [Cursor Skills](https://cursor.com/docs/skills).
+Official references: [Cursor plugins](https://cursor.com/docs/plugins), [Cursor MCP](https://cursor.com/docs/context/mcp), [Cursor Agent CLI MCP commands](https://cursor.com/docs/cli/reference/parameters), and [Cursor Skills](https://cursor.com/docs/skills).

--- a/docs/cursor/README.zh-CN.md
+++ b/docs/cursor/README.zh-CN.md
@@ -2,9 +2,15 @@
 
 [English](README.md) · [返回 Plugin 首页](../../README.zh-CN.md)
 
-## 1. 安装 Skill
+## 从 Cursor Marketplace 安装
 
-Clone 本仓库，并把 canonical Skill 复制到 Cursor 支持的个人目录：
+在 Cursor 中打开 `/add-plugin`，搜索 **StarryKit**，然后选择 **Install**。Cursor 会同时安装 canonical StarryKit Skill，并配置 Hosted MCP。
+
+Marketplace 条目目前正在审核。在正式上架前，请使用下面的手动安装方式。
+
+## 手动安装
+
+Clone 本仓库，并把 canonical Skill 复制到 Cursor 的个人 Skill 目录：
 
 ```sh
 git clone https://github.com/StarryKit/starrykit-plugin.git
@@ -12,21 +18,22 @@ mkdir -p ~/.cursor/skills
 cp -R starrykit-plugin/skills/starrykit ~/.cursor/skills/
 ```
 
-## 2. 配置 MCP
-
-把下面的配置加入全局 `~/.cursor/mcp.json`，或单个项目的 `.cursor/mcp.json`：
+然后把下面的配置加入全局 `~/.cursor/mcp.json`，或单个项目的 `.cursor/mcp.json`：
 
 ```json
 {
   "mcpServers": {
     "starrykit": {
+      "type": "http",
       "url": "https://mcp.starrykit.com/mcp"
     }
   }
 }
 ```
 
-打开 Cursor 的 MCP 设置，并在提示时完成 OAuth。Cursor Agent CLI 用户也可以运行：
+## 连接账号
+
+打开 Cursor 的 MCP 设置，并在提示时通过浏览器完成 OAuth。Cursor Agent CLI 用户也可以运行：
 
 ```sh
 cursor-agent mcp login starrykit
@@ -35,8 +42,8 @@ cursor-agent mcp list-tools starrykit
 
 不要添加账号凭据或静态 Authorization header。
 
-## 3. 验证
+## 验证
 
-让 Cursor Agent 使用 StarryKit 列出你有权访问的视觉文档。能够调用 `list_documents` 即表示安装完成。
+让 Cursor Agent 使用 StarryKit 列出你有权访问的视觉文档。当它能够调用 `list_documents`，并返回已授权文档或没有认证错误的空结果时，安装即完成。
 
-官方参考：[Cursor MCP](https://cursor.com/docs/context/mcp)、[Cursor Agent CLI MCP 命令](https://cursor.com/docs/cli/reference/parameters)、[Cursor Skills](https://cursor.com/docs/skills)。
+官方参考：[Cursor Plugins](https://cursor.com/docs/plugins)、[Cursor MCP](https://cursor.com/docs/context/mcp)、[Cursor Agent CLI MCP 命令](https://cursor.com/docs/cli/reference/parameters)和 [Cursor Skills](https://cursor.com/docs/skills)。

--- a/docs/development.md
+++ b/docs/development.md
@@ -8,7 +8,7 @@ This repository is the installable client-side StarryKit Plugin bundle. It conta
 
 The test verifies that:
 
-- the Codex, Claude, and Grok manifests keep the same release identity and component paths while allowing host-specific marketing copy;
+- the Codex, Claude, Grok, and Cursor manifests keep the same release identity and component paths while allowing host-specific marketing copy;
 - the bundled MCP config points to the production HTTPS endpoint without embedded credentials;
 - the canonical Skill has valid metadata, references the production MCP endpoint, and preserves essential safety boundaries;
 - English and Chinese user docs exist for every documented host;

--- a/mcp.json
+++ b/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "starrykit": {
+      "type": "http",
+      "url": "https://mcp.starrykit.com/mcp"
+    }
+  }
+}

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -21,35 +21,50 @@ describe("plugin bundle", () => {
     const codex = json(".codex-plugin/plugin.json");
     const claude = json(".claude-plugin/plugin.json");
     const grok = json(".grok-plugin/plugin.json");
+    const cursor = json(".cursor-plugin/plugin.json");
     const packageManifest = json("package.json");
 
     assert.equal(codex.name, "starrykit-plugin");
     assert.equal(claude.name, codex.name);
     assert.equal(grok.name, codex.name);
+    assert.equal(cursor.name, codex.name);
     assert.equal(claude.version, codex.version);
     assert.equal(grok.version, codex.version);
+    assert.equal(cursor.version, codex.version);
     assert.equal(packageManifest.version, codex.version);
     assert.equal(codex.interface.displayName, "StarryKit");
     assert.equal(claude.displayName, "StarryKit");
     assert.equal(grok.displayName, "StarryKit");
+    assert.equal(cursor.displayName, "StarryKit");
     assert.deepEqual(claude.author, codex.author);
     assert.deepEqual(grok.author, codex.author);
+    assert.equal(cursor.author.name, codex.author.name);
     assert.equal(claude.homepage, codex.homepage);
     assert.equal(grok.homepage, codex.homepage);
+    assert.equal(cursor.homepage, codex.homepage);
     assert.equal(claude.repository, codex.repository);
     assert.equal(grok.repository, codex.repository);
+    assert.equal(cursor.repository, codex.repository);
     assert.equal(codex.license, "MIT");
     assert.equal(claude.license, "MIT");
     assert.equal(grok.license, "MIT");
+    assert.equal(cursor.license, "MIT");
     assert.equal(codex.mcpServers, "./.mcp.json");
     assert.equal(codex.apps, "./.app.json");
     assert.equal(claude.mcpServers, "./.mcp.json");
     assert.equal(grok.mcpServers, "./.mcp.json");
+    assert.equal(cursor.mcpServers, "./mcp.json");
     assert.equal(claude.skills, "./skills/");
     assert.equal(grok.skills, "./skills/");
+    assert.equal(cursor.skills, "./skills/");
     assert.notEqual(grok.description, claude.description, "Grok copy should remain host-specific");
+    assert.notEqual(cursor.description, claude.description, "Cursor copy should remain host-specific");
+    assert.equal(cursor.category, "productivity");
     assert.equal(grok.logo, "assets/brand/starrykit-app-icon.png");
     assert.ok(existsSync(resolve(ROOT, grok.logo)));
+    assert.equal(cursor.logo, "assets/brand/starrykit-app-icon.png");
+    assert.ok(existsSync(resolve(ROOT, cursor.logo)));
+    assert.ok(!existsSync(resolve(ROOT, ".cursor-plugin/marketplace.json")), "single-plugin Cursor repo must not ship a marketplace manifest");
   });
 
   it("installs the registered StarryKit app with the Codex plugin", () => {
@@ -97,11 +112,13 @@ describe("plugin bundle", () => {
 
   it("uses the production Hosted MCP without embedded credentials", () => {
     const mcp = json(".mcp.json");
+    const cursorMcp = json("mcp.json");
     assert.deepEqual(mcp, {
       mcpServers: {
         starrykit: { type: "http", url: PRODUCTION_MCP_URL },
       },
     });
+    assert.deepEqual(cursorMcp, mcp, "Cursor MCP config must match the canonical MCP config");
 
     const serialized = JSON.stringify(mcp);
     for (const forbidden of ["apiKey", "accessToken", "clientSecret", "Authorization", "mcp.stage.starrykit.com"]) {


### PR DESCRIPTION
## Summary
- add a native Cursor plugin manifest and Cursor-standard `mcp.json`
- add Marketplace-first Cursor installation docs in English and Chinese
- lock Cursor release identity and MCP configuration against cross-host drift

## Validation
- `npm test`
- manifest validated against Cursor's official `plugin.schema.json`

## Notes
- version remains `0.4.0`
- category is `productivity`
- no `.cursor-plugin/marketplace.json` is included because this is a single-plugin repository