### PR TITLE
Document Cursor plugin install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,13 @@ codex plugin add starrykit-plugin@starrykit
 
 ### Cursor
 
-Open `/add-plugin` in Cursor and search for **StarryKit**. While the Marketplace listing is under review, use the [manual Cursor setup](docs/cursor/README.md).
+While the Marketplace listing is under review, install the complete Plugin locally:
+
+```bash
+git clone https://github.com/StarryKit/starrykit-plugin.git ~/.cursor/plugins/local/starrykit-plugin
+```
+
+Restart Cursor or run **Developer: Reload Window**. See the [Cursor installation guide](docs/cursor/README.md) for OAuth and verification.
 
 ### Grok Build
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -49,7 +49,13 @@ codex plugin add starrykit-plugin@starrykit
 
 ### Cursor
 
-在 Cursor 中打开 `/add-plugin`，搜索 **StarryKit**。Marketplace 上架审核期间，请使用 [Cursor 手动安装指南](docs/cursor/README.zh-CN.md)。
+Marketplace 上架审核期间，可以把完整 Plugin 安装到 Cursor 的本地目录：
+
+```bash
+git clone https://github.com/StarryKit/starrykit-plugin.git ~/.cursor/plugins/local/starrykit-plugin
+```
+
+重启 Cursor，或运行 **Developer: Reload Window**。OAuth 和验证步骤请查看 [Cursor 安装指南](docs/cursor/README.zh-CN.md)。
 
 ### Grok Build
 

--- a/docs/cursor/README.md
+++ b/docs/cursor/README.md
@@ -8,17 +8,17 @@ Open `/add-plugin` in Cursor, search for **StarryKit**, and select **Install**. 
 
 The Marketplace listing is currently under review. Until it is available, use the manual setup below.
 
-## Manual setup
+## Install the Plugin manually
 
-Clone this repository and copy the canonical Skill into Cursor's personal Skill directory:
+Clone the complete Plugin into Cursor's local Plugin directory:
 
 ```sh
-git clone https://github.com/StarryKit/starrykit-plugin.git
-mkdir -p ~/.cursor/skills
-cp -R starrykit-plugin/skills/starrykit ~/.cursor/skills/
+git clone https://github.com/StarryKit/starrykit-plugin.git ~/.cursor/plugins/local/starrykit-plugin
 ```
 
-Then add this entry to global `~/.cursor/mcp.json`, or to `.cursor/mcp.json` for one project:
+Restart Cursor or run **Developer: Reload Window**. Cursor loads the bundled Skill and MCP configuration from the Plugin.
+
+If you only want to configure the MCP without installing the Plugin, add this entry to global `~/.cursor/mcp.json`, or to `.cursor/mcp.json` for one project:
 
 ```json
 {

--- a/docs/cursor/README.zh-CN.md
+++ b/docs/cursor/README.zh-CN.md
@@ -8,17 +8,17 @@
 
 Marketplace 条目目前正在审核。在正式上架前，请使用下面的手动安装方式。
 
-## 手动安装
+## 手动安装 Plugin
 
-Clone 本仓库，并把 canonical Skill 复制到 Cursor 的个人 Skill 目录：
+把完整 Plugin Clone 到 Cursor 的本地 Plugin 目录：
 
 ```sh
-git clone https://github.com/StarryKit/starrykit-plugin.git
-mkdir -p ~/.cursor/skills
-cp -R starrykit-plugin/skills/starrykit ~/.cursor/skills/
+git clone https://github.com/StarryKit/starrykit-plugin.git ~/.cursor/plugins/local/starrykit-plugin
 ```
 
-然后把下面的配置加入全局 `~/.cursor/mcp.json`，或单个项目的 `.cursor/mcp.json`：
+重启 Cursor，或运行 **Developer: Reload Window**。Cursor 会从 Plugin 中加载 bundled Skill 和 MCP 配置。
+
+如果只想配置 MCP、不安装 Plugin，可以把下面的配置加入全局 `~/.cursor/mcp.json`，或单个项目的 `.cursor/mcp.json`：
 
 ```json
 {


### PR DESCRIPTION
## Summary
- show the complete local Cursor Plugin installation command in both root READMEs
- update the Cursor guides to install the whole Plugin instead of copying only the Skill
- retain standalone MCP configuration as an optional fallback

## Validation
- `npm test`