### PR TITLE
Link official ChatGPT plugin listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,12 +40,9 @@ claude plugin marketplace add StarryKit/starrykit-plugin
 claude plugin install starrykit-plugin@starrykit
 ```
 
-### Codex
+### ChatGPT & Codex
 
-```bash
-codex plugin marketplace add StarryKit/starrykit-plugin
-codex plugin add starrykit-plugin@starrykit
-```
+[Install StarryKit from the official ChatGPT Plugin Directory.](https://chatgpt.com/plugins/plugin_asdk_app_6a7ad0afe3ec819188809d7760d8bc2a)
 
 ### Cursor
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -40,12 +40,9 @@ claude plugin marketplace add StarryKit/starrykit-plugin
 claude plugin install starrykit-plugin@starrykit
 ```
 
-### Codex
+### ChatGPT & Codex
 
-```bash
-codex plugin marketplace add StarryKit/starrykit-plugin
-codex plugin add starrykit-plugin@starrykit
-```
+[前往 ChatGPT 官方 Plugin Directory 安装 StarryKit。](https://chatgpt.com/plugins/plugin_asdk_app_6a7ad0afe3ec819188809d7760d8bc2a)
 
 ### Cursor
 

--- a/tests/plugin.test.mjs
+++ b/tests/plugin.test.mjs
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 
 const ROOT = resolve(import.meta.dirname, "..");
 const PRODUCTION_MCP_URL = "https://mcp.starrykit.com/mcp";
+const OFFICIAL_CHATGPT_PLUGIN_URL = "https://chatgpt.com/plugins/plugin_asdk_app_6a7ad0afe3ec819188809d7760d8bc2a";
 const DEVELOPMENT_APP_ID = "asdk_app_6a7d4856434081919523a0971a413bb4";
 const HOSTS = ["codex", "claude-code", "grok-build", "cursor", "opencode", "openclaw", "pi", "other-hosts"];
 
@@ -78,6 +79,15 @@ describe("plugin bundle", () => {
         },
       },
     });
+  });
+
+  it("links ChatGPT and Codex users to the official Plugin Directory listing", () => {
+    for (const path of ["README.md", "README.zh-CN.md"]) {
+      const source = read(path);
+      assert.ok(source.includes(OFFICIAL_CHATGPT_PLUGIN_URL), `${path} must link to the official ChatGPT Plugin listing`);
+      assert.ok(!source.includes("codex plugin marketplace add"), `${path} must not advertise the legacy Codex marketplace flow`);
+      assert.ok(!source.includes("codex plugin add"), `${path} must not advertise the legacy Codex install flow`);
+    }
   });
 
   it("provides concise Codex discovery metadata and starter prompts", () => {


### PR DESCRIPTION
## Summary
- replace the legacy Codex marketplace commands with the official StarryKit listing in the ChatGPT Plugin Directory
- update both English and Chinese README sections
- add a regression test that locks the official listing URL and rejects the legacy install flow

## Validation
- `npm test`